### PR TITLE
fix(cypress): Merge all steps of a scenario into a single test.

### DIFF
--- a/createTestFromScenario.js
+++ b/createTestFromScenario.js
@@ -22,7 +22,7 @@ const createTestFromScenario = (scenario, backgroundSection) => {
       });
 
       exampleValues.forEach((_, index) => {
-        it(scenario.name, () => {
+        it(`${scenario.name} (example #${index + 1})`, () => {
           if (backgroundSection) {
             backgroundSection.steps.forEach(stepTest);
           }

--- a/createTestFromScenario.js
+++ b/createTestFromScenario.js
@@ -8,7 +8,7 @@ const stepTest = stepDetails => {
   resolveAndRunStepDefinition(stepDetails);
 };
 
-const createTestFromScenario = scenario => {
+const createTestFromScenario = (scenario, backgroundSection) => {
   if (scenario.examples) {
     scenario.examples.forEach(example => {
       const exampleValues = [];
@@ -23,6 +23,10 @@ const createTestFromScenario = scenario => {
 
       exampleValues.forEach((_, index) => {
         it(scenario.name, () => {
+          if (backgroundSection) {
+            backgroundSection.steps.forEach(stepTest);
+          }
+
           scenario.steps.forEach(step => {
             const newStep = Object.assign({}, step);
             Object.entries(exampleValues[index]).forEach(column => {
@@ -41,6 +45,9 @@ const createTestFromScenario = scenario => {
     });
   } else {
     it(scenario.name, () => {
+      if (backgroundSection) {
+        backgroundSection.steps.forEach(stepTest);
+      }
       scenario.steps.forEach(step => stepTest(step));
     });
   }

--- a/createTestFromScenario.js
+++ b/createTestFromScenario.js
@@ -4,30 +4,30 @@
 require("mocha-steps");
 const { resolveAndRunStepDefinition } = require("./resolveStepDefinition");
 
-const stepTest = stepDetails =>
-  step(`${stepDetails.keyword} ${stepDetails.text}`, () => {
-    resolveAndRunStepDefinition(stepDetails);
-  });
+const stepTest = stepDetails => {
+  cy.log(`${stepDetails.keyword} ${stepDetails.text}`)
+  resolveAndRunStepDefinition(stepDetails);
+}
 
 const createTestFromScenario = scenario => {
-  describe(scenario.name, () => {
-    if (scenario.examples) {
-      scenario.examples.forEach(example => {
-        const exampleValues = [];
+  if (scenario.examples) {
+    scenario.examples.forEach(example => {
+      const exampleValues = [];
 
-        example.tableBody.forEach((row, rowIndex) => {
-          example.tableHeader.cells.forEach((header, headerIndex) => {
-            exampleValues[rowIndex] = Object.assign(
-              {},
-              exampleValues[rowIndex],
-              {
-                [header.value]: row.cells[headerIndex].value
-              }
-            );
-          });
+      example.tableBody.forEach((row, rowIndex) => {
+        example.tableHeader.cells.forEach((header, headerIndex) => {
+          exampleValues[rowIndex] = Object.assign(
+            {},
+            exampleValues[rowIndex],
+            {
+              [header.value]: row.cells[headerIndex].value
+            }
+          );
         });
+      });
 
-        exampleValues.forEach((_, index) => {
+      exampleValues.forEach((_, index) => {
+        it(scenario.name, () => {
           scenario.steps.forEach(step => {
             const newStep = Object.assign({}, step);
             Object.entries(exampleValues[index]).forEach(column => {
@@ -40,13 +40,17 @@ const createTestFromScenario = scenario => {
             });
 
             stepTest(newStep);
-          });
+          })
+
         });
       });
-    } else {
+    })
+  }
+  else {
+    it(scenario.name, () => {
       scenario.steps.forEach(step => stepTest(step));
-    }
-  });
+    })
+  }
 };
 
 module.exports = {

--- a/createTestFromScenario.js
+++ b/createTestFromScenario.js
@@ -1,6 +1,4 @@
 /* eslint-disable prefer-template */
-
-require("mocha-steps");
 const { resolveAndRunStepDefinition } = require("./resolveStepDefinition");
 
 const stepTest = stepDetails => {

--- a/createTestFromScenario.js
+++ b/createTestFromScenario.js
@@ -1,13 +1,12 @@
 /* eslint-disable prefer-template */
-/* global step */
 
 require("mocha-steps");
 const { resolveAndRunStepDefinition } = require("./resolveStepDefinition");
 
 const stepTest = stepDetails => {
-  cy.log(`${stepDetails.keyword} ${stepDetails.text}`)
+  cy.log(`${stepDetails.keyword} ${stepDetails.text}`);
   resolveAndRunStepDefinition(stepDetails);
-}
+};
 
 const createTestFromScenario = scenario => {
   if (scenario.examples) {
@@ -16,13 +15,9 @@ const createTestFromScenario = scenario => {
 
       example.tableBody.forEach((row, rowIndex) => {
         example.tableHeader.cells.forEach((header, headerIndex) => {
-          exampleValues[rowIndex] = Object.assign(
-            {},
-            exampleValues[rowIndex],
-            {
-              [header.value]: row.cells[headerIndex].value
-            }
-          );
+          exampleValues[rowIndex] = Object.assign({}, exampleValues[rowIndex], {
+            [header.value]: row.cells[headerIndex].value
+          });
         });
       });
 
@@ -40,16 +35,14 @@ const createTestFromScenario = scenario => {
             });
 
             stepTest(newStep);
-          })
-
+          });
         });
       });
-    })
-  }
-  else {
+    });
+  } else {
     it(scenario.name, () => {
       scenario.steps.forEach(step => stepTest(step));
-    })
+    });
   }
 };
 

--- a/createTestsFromFeature.js
+++ b/createTestsFromFeature.js
@@ -1,6 +1,6 @@
 const { createTestFromScenario } = require("./createTestFromScenario");
 
-const createTestsFromFeature = parsedFeature =>
+const createTestsFromFeature = parsedFeature => {
   describe(parsedFeature.feature.name, () => {
     const backgroundSection = parsedFeature.feature.children.find(
       section => section.type === "Background"
@@ -9,12 +9,10 @@ const createTestsFromFeature = parsedFeature =>
       section => section.type !== "Background"
     );
     otherSections.forEach(section => {
-      if (backgroundSection) {
-        createTestFromScenario(backgroundSection);
-      }
-      createTestFromScenario(section);
+      createTestFromScenario(section, backgroundSection);
     });
   });
+};
 
 module.exports = {
   createTestsFromFeature

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-cucumber-preprocessor",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6870,11 +6870,6 @@
       "requires": {
         "minimist": "0.0.8"
       }
-    },
-    "mocha-steps": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mocha-steps/-/mocha-steps-1.1.0.tgz",
-      "integrity": "sha1-QLq4kVfvRbsCVIHKbzFtBpg/LfA="
     },
     "module-deps": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "debug": "^3.0.1",
     "gherkin": "^5.0.0",
     "glob": "^7.1.2",
-    "mocha-steps": "^1.1.0",
     "through": "^2.3.8"
   },
   "devDependencies": {

--- a/resolveStepDefinition.test.js
+++ b/resolveStepDefinition.test.js
@@ -1,4 +1,5 @@
 /* eslint-disable global-require */
+/* global jest */
 const fs = require("fs");
 const { Parser } = require("gherkin");
 const { createTestsFromFeature } = require("./createTestsFromFeature");
@@ -7,6 +8,9 @@ const { when, then, given } = require("./resolveStepDefinition");
 window.when = when;
 window.then = then;
 window.given = given;
+window.cy = {
+  log: jest.fn()
+};
 
 const readAndParseFeatureFile = featureFilePath => {
   const spec = fs.readFileSync(featureFilePath);


### PR DESCRIPTION
This is a proof of concept / illustration regardin the issue #43 . It is not meant to be merged right now or as-is, but this issue may force me to abandon cypress so i'd like this proposal to be considered.

I've put a cy.log() command to mark the start of each step, but this is not as good as before wrt reporting. Once cypress-io/cypress#686 is implemented, it should be possible to go back to separate tests by controlling the state clearing within a scenario. In the meantime, I think this is the only way to use gherkin + cypress in my use case (keep state between tests), and it's very likely that other people will run into the same issue.

- [x] Merge all steps of a scenario into only one test
- [x] Transform "background" into a beforeEach block
- [x] Handle Scenario outline
- [ ] Make sure other parts of the module are not broken
- [x] Update tests