### PR TITLE
begins documenting cypress.json configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,14 @@ Step definition files are by default in: cypress/support/step_definitions. If yo
   }
 ```
 
+You can also create a `cypress.json` file, for example, to configure Cypress to look for your features in a different location:
+
+```json
+{
+  "integrationFolder": "features"
+}
+```
+
 ## Running
 
 Run your cypress the way you would normally do :) click on a .feature file on the list of specs, and see the magic happening!


### PR DESCRIPTION
In my team we like using the Cucumber standard of top-level `features/` directory to contain our `.feature` files. Cypress Cucumber Preprocessor allows for configuring this but the feature isn't documented, so this makes a start on that.

I know other config options exist, e.g.

```json
    "fileServerFolder": "test/cypress",
    "fixturesFolder": "test/cypress/fixtures",
    "integrationFolder": "test/cypress/features",
    "supportFile": "test/cypress/support/index.js",
    "pluginsFile": "test/cypress/plugins/index.js",
    "videosFolder": "test/cypress/videos",
    "screenshotsFolder": "test/cypress/screenshots",
    "video": false
```

...but don't have a definitive list, and not sure how comprehensive you want the README to be.