### PR TITLE
Handle custom parameter types

### DIFF
--- a/cypress/integration/CustomParameterTypes.feature
+++ b/cypress/integration/CustomParameterTypes.feature
@@ -1,0 +1,12 @@
+Feature: Custom Parameter Types
+
+  As a cucumber cypress plugin which handles Custom Parameter Types
+  I want to allow people to add custom parameter types and use them into their step definitions
+
+  Scenario: Play an A on my piano
+    When I press the 1st key of my piano
+    Then I should hear an A sound
+
+  Scenario: Play an E on my piano
+    When I press the 26th key of my piano
+    Then I should hear an E sound

--- a/cypress/support/step_definitions/customParameterTypes.js
+++ b/cypress/support/step_definitions/customParameterTypes.js
@@ -1,0 +1,26 @@
+/* global defineParameterType, then, when */
+
+const notes = ["A", "B", "C", "D", "E", "F", "G"];
+
+defineParameterType({
+  name: "note",
+  regexp: new RegExp(notes.join("|"))
+});
+
+defineParameterType({
+  name: "ordinal",
+  regexp: /(\d+)(?:st|nd|rd|th)/,
+  transformer(s) {
+    return parseInt(s, 10);
+  }
+});
+
+let keySound = null;
+
+when("I press the {ordinal} key of my piano", number => {
+  keySound = notes[(number - 1) % 7];
+});
+
+then("I should hear a(n) {note} sound", note => {
+  expect(note).to.equal(keySound);
+});

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ const watchers = {};
 // feature file
 const createCucumber = (spec, definitions) =>
   `
-  const {resolveAndRunStepDefinition, given, when, then} = require('cypress-cucumber-preprocessor/resolveStepDefinition');
+  const {resolveAndRunStepDefinition, defineParameterType, given, when, then} = require('cypress-cucumber-preprocessor/resolveStepDefinition');
   const Given = given;
   const When = when;
   const Then = then;

--- a/resolveStepDefinition.js
+++ b/resolveStepDefinition.js
@@ -1,24 +1,34 @@
 const DataTable = require("cucumber/lib/models/data_table").default;
 const {
+  defineParameterType
+} = require("cucumber/lib/support_code_library_builder/define_helpers");
+const {
   CucumberExpression,
   RegularExpression,
   ParameterTypeRegistry
 } = require("cucumber-expressions");
 
-const parameterTypeRegistry = new ParameterTypeRegistry();
-
 class StepDefinitionRegistry {
   constructor() {
     this.definitions = {};
     this.runtime = {};
+    this.options = {
+      parameterTypeRegistry: new ParameterTypeRegistry()
+    };
 
     this.definitions = [];
     this.runtime = (matcher, implementation) => {
       let expression;
       if (matcher instanceof RegExp) {
-        expression = new RegularExpression(matcher, parameterTypeRegistry);
+        expression = new RegularExpression(
+          matcher,
+          this.options.parameterTypeRegistry
+        );
       } else {
-        expression = new CucumberExpression(matcher, parameterTypeRegistry);
+        expression = new CucumberExpression(
+          matcher,
+          this.options.parameterTypeRegistry
+        );
       }
       this.definitions.push({ implementation, expression });
     };
@@ -66,5 +76,6 @@ module.exports = {
   },
   then: (expression, implementation) => {
     stepDefinitionRegistry.runtime(expression, implementation);
-  }
+  },
+  defineParameterType: defineParameterType(stepDefinitionRegistry)
 };

--- a/resolveStepDefinition.test.js
+++ b/resolveStepDefinition.test.js
@@ -3,8 +3,14 @@
 const fs = require("fs");
 const { Parser } = require("gherkin");
 const { createTestsFromFeature } = require("./createTestsFromFeature");
-const { when, then, given } = require("./resolveStepDefinition");
+const {
+  defineParameterType,
+  when,
+  then,
+  given
+} = require("./resolveStepDefinition");
 
+window.defineParameterType = defineParameterType;
 window.when = when;
 window.then = then;
 window.given = given;
@@ -62,5 +68,14 @@ describe("Regexp", () => {
   require("./cypress/support/step_definitions/regexp");
   createTestsFromFeature(
     readAndParseFeatureFile("./cypress/integration/RegularExpressions.feature")
+  );
+});
+
+describe("Custom Parameter Types", () => {
+  require("./cypress/support/step_definitions/customParameterTypes");
+  createTestsFromFeature(
+    readAndParseFeatureFile(
+      "./cypress/integration/CustomParameterTypes.feature"
+    )
   );
 });


### PR DESCRIPTION
This PR allows to add custom parameter types like it's defined in the [Cumcumber's documentation](https://docs.cucumber.io/cucumber/cucumber-expressions/#custom-parameter-types).

To do this, use the `defineParameterType` function into your step definitions file like that:

```js
defineParameterType({
  name: 'ordinal',
  regexp: /(\d+)(?:st|nd|rd|th)/,
  transformer(s) {
    return parseInt(s, 10);
  },
})
```