### PR TITLE
Simplify typescript setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,12 +175,13 @@ const cucumber = require("cypress-cucumber-preprocessor").default;
 const browserify = require("@cypress/browserify-preprocessor");
 
 module.exports = (on) => {
-  on("file:preprocessor", file => {
-      browserify.defaultOptions.browserifyOptions.plugin.push(["tsify"])
-      return cucumber(
-        browserify.defaultOptions
-      )(file);
-  });
+  const options = browserify.defaultOptions;
+
+  options.browserifyOptions.plugin.unshift(['tsify']);
+  // Or, if you need a custom tsconfig.json for your test files:
+  // options.browserifyOptions.plugin.unshift(['tsify', {project: 'path/to/other/tsconfig.json'}]);
+  
+  on("file:preprocessor", cucumber(options));
 };
 ```
 


### PR DESCRIPTION
It turns out the typescript setup can be accomplished with less effort than what was previously in the README. I also included a comment note about using a custom `tsconfig.json` file for the cypress tests.