### PR TITLE
Add webpack loader

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,63 +1,11 @@
 /* eslint-disable no-eval */
 const fs = require("fs");
 const through = require("through");
-const path = require("path");
 const browserify = require("@cypress/browserify-preprocessor");
 const log = require("debug")("cypress:cucumber");
-const glob = require("glob");
-const cosmiconfig = require("cosmiconfig");
 const chokidar = require("chokidar");
-
-// This is the template for the file that we will send back to cypress instead of the text of a
-// feature file
-const createCucumber = (spec, toRequire) =>
-  `
-  const {resolveAndRunStepDefinition, defineParameterType, given, when, then} = require('cypress-cucumber-preprocessor/resolveStepDefinition');
-  const Given = window.Given = window.given = given;
-  const When = window.When = window.when = when;
-  const Then = window.Then = window.then = then;
-  window.defineParameterType = defineParameterType;
-  const { createTestsFromFeature } = require('cypress-cucumber-preprocessor/createTestsFromFeature');
-  ${eval(toRequire).join("\n")}
-  const {Parser, Compiler} = require('gherkin');
-  const spec = \`${spec}\`
-  const gherkinAst = new Parser().parse(spec);
-  
-  createTestsFromFeature(gherkinAst);
-  `;
-
-const stepDefinitionPath = () => {
-  const appRoot = process.cwd();
-
-  const explorer = cosmiconfig("cypress-cucumber-preprocessor", { sync: true });
-  const loaded = explorer.load();
-  if (loaded && loaded.config && loaded.config.step_definitions) {
-    return path.resolve(appRoot, loaded.config.step_definitions);
-  }
-
-  // XXX Deprecated, left here for backward compability
-  const cypressOptions = JSON.parse(
-    fs.readFileSync(`${appRoot}/cypress.json`, "utf-8")
-  );
-  if (cypressOptions && cypressOptions.fileServerFolder) {
-    return `${cypressOptions.fileServerFolder}/support/step_definitions`;
-  }
-
-  return `${appRoot}/cypress/support/step_definitions`;
-};
-const createPattern = () => `${stepDefinitionPath()}/**/*.+(js|ts)`;
-
-const pattern = createPattern();
-
-const getStepDefinitionsPaths = () => [].concat(glob.sync(pattern));
-
-const compile = spec => {
-  log("compiling", spec);
-  const stepDefinitionsToRequire = getStepDefinitionsPaths().map(
-    sdPath => `require('${sdPath}')`
-  );
-  return createCucumber(spec, stepDefinitionsToRequire);
-};
+const compile = require("./loader.js");
+const stepDefinitionPath = require("./stepDefinitionPath.js");
 
 const transform = file => {
   let data = "";

--- a/loader.js
+++ b/loader.js
@@ -1,0 +1,36 @@
+/* eslint-disable no-eval */
+const log = require("debug")("cypress:cucumber");
+const glob = require("glob");
+const stepDefinitionPath = require("./stepDefinitionPath.js");
+
+// This is the template for the file that we will send back to cypress instead of the text of a
+// feature file
+const createCucumber = (spec, toRequire) =>
+  `
+  const {resolveAndRunStepDefinition, defineParameterType, given, when, then} = require('cypress-cucumber-preprocessor/resolveStepDefinition');
+  const Given = window.Given = window.given = given;
+  const When = window.When = window.when = when;
+  const Then = window.Then = window.then = then;
+  window.defineParameterType = defineParameterType;
+  const { createTestsFromFeature } = require('cypress-cucumber-preprocessor/createTestsFromFeature');
+  ${eval(toRequire).join("\n")}
+  const {Parser, Compiler} = require('gherkin');
+  const spec = \`${spec}\`
+  const gherkinAst = new Parser().parse(spec);
+
+  createTestsFromFeature(gherkinAst);
+  `;
+
+const createPattern = () => `${stepDefinitionPath()}/**/*.+(js|ts)`;
+
+const pattern = createPattern();
+
+const getStepDefinitionsPaths = () => [].concat(glob.sync(pattern));
+
+module.exports = spec => {
+  log("compiling", spec);
+  const stepDefinitionsToRequire = getStepDefinitionsPaths().map(
+    sdPath => `require('${sdPath}')`
+  );
+  return createCucumber(spec, stepDefinitionsToRequire);
+};

--- a/stepDefinitionPath.js
+++ b/stepDefinitionPath.js
@@ -1,0 +1,23 @@
+const fs = require("fs");
+const path = require("path");
+const cosmiconfig = require("cosmiconfig");
+
+module.exports = () => {
+  const appRoot = process.cwd();
+
+  const explorer = cosmiconfig("cypress-cucumber-preprocessor", { sync: true });
+  const loaded = explorer.load();
+  if (loaded && loaded.config && loaded.config.step_definitions) {
+    return path.resolve(appRoot, loaded.config.step_definitions);
+  }
+
+  // XXX Deprecated, left here for backward compability
+  const cypressOptions = JSON.parse(
+    fs.readFileSync(`${appRoot}/cypress.json`, "utf-8")
+  );
+  if (cypressOptions && cypressOptions.fileServerFolder) {
+    return `${cypressOptions.fileServerFolder}/support/step_definitions`;
+  }
+
+  return `${appRoot}/cypress/support/step_definitions`;
+};


### PR DESCRIPTION
Solution for #114
The only thing that needed is to move `compile` function from `index.js` to a separate module.

Example configuration
-----------------------

Sample `webpack.config.js` may look like this:
```js
module.exports = {
  resolve: {
    extensions: [".ts", ".js"]
  },
  module: {
    rules: [
      {
        test: /\.ts$/,
        exclude: [/node_modules/],
        use: [
          {
            loader: "ts-loader"
          }
        ]
      },
      {
        test: /\.feature$/,
        use: [
          {
            loader: "cypress-cucumber-preprocessor/loader"
          }
        ]
      }
    ]
  }
}
```
and `plugins/index.js` need just to include webpack:
```js
const webpack = require("@cypress/webpack-preprocessor")

module.exports = on => {
  const options = {
    webpackOptions: require("../webpack.config.js")
  }
  on("file:preprocessor", webpack(options))
}

```