### PR TITLE
and and but step definition support #82

### DIFF
--- a/cypress/integration/AndAndButSteps.feature
+++ b/cypress/integration/AndAndButSteps.feature
@@ -1,0 +1,11 @@
+Feature: Using And and but
+Scenario: With an And everything is find
+    Given I do something
+    And Something else
+    Then I happily work
+
+Scenario: With a But also the step definition 
+    Given I dont do something
+    And it is sunday
+    Then I stream on twitch
+    But only when not tired

--- a/cypress/support/step_definitions/and_and_but_steps.js
+++ b/cypress/support/step_definitions/and_and_but_steps.js
@@ -1,0 +1,34 @@
+/* global then, when, and, but */
+/* eslint-env mocha */
+
+let stepCounter = 0;
+let step2Counter = 0;
+
+when("I do something", () => {
+  stepCounter += 1;
+});
+
+and("Something else", () => {
+  stepCounter += 2;
+});
+
+then("I happily work", () => {
+  expect(stepCounter).to.equal(3);
+});
+
+when("I dont do something", () => {
+  step2Counter += 1;
+});
+
+and("it is sunday", () => {
+  step2Counter += 2;
+});
+
+then("I stream on twitch", () => {
+  expect(step2Counter).to.equal(3);
+  step2Counter += 1;
+});
+
+but("only when not tired", () => {
+  expect(step2Counter).to.equal(4);
+});

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -11,7 +11,7 @@ const createCucumber = (spec, toRequire) =>
   const When = window.When = window.when = when;
   const Then = window.Then = window.then = then;
   const And = window.And = window.and = and;
-  const But = window.But = window.and = but;
+  const But = window.But = window.but = but;
   window.defineParameterType = defineParameterType;
   const { createTestsFromFeature } = require('cypress-cucumber-preprocessor/lib/createTestsFromFeature');
   ${eval(toRequire).join("\n")}

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -6,10 +6,12 @@ const { getStepDefinitionsPaths } = require("./getStepDefinitionsPaths");
 // feature file
 const createCucumber = (spec, toRequire) =>
   `
-  const {resolveAndRunStepDefinition, defineParameterType, given, when, then} = require('cypress-cucumber-preprocessor/lib/resolveStepDefinition');
+  const {resolveAndRunStepDefinition, defineParameterType, given, when, then, and, but} = require('cypress-cucumber-preprocessor/lib/resolveStepDefinition');
   const Given = window.Given = window.given = given;
   const When = window.When = window.when = when;
   const Then = window.Then = window.then = then;
+  const And = window.And = window.and = and;
+  const But = window.But = window.and = but;
   window.defineParameterType = defineParameterType;
   const { createTestsFromFeature } = require('cypress-cucumber-preprocessor/lib/createTestsFromFeature');
   ${eval(toRequire).join("\n")}

--- a/lib/resolveStepDefinition.js
+++ b/lib/resolveStepDefinition.js
@@ -132,5 +132,11 @@ module.exports = {
   then: (expression, implementation) => {
     stepDefinitionRegistry.runtime(expression, implementation);
   },
+  and: (expression, implementation) => {
+    stepDefinitionRegistry.runtime(expression, implementation);
+  },
+  but: (expression, implementation) => {
+    stepDefinitionRegistry.runtime(expression, implementation);
+  },
   defineParameterType: defineParameterType(stepDefinitionRegistry)
 };

--- a/lib/resolveStepDefinition.test.js
+++ b/lib/resolveStepDefinition.test.js
@@ -7,13 +7,17 @@ const {
   defineParameterType,
   when,
   then,
-  given
+  given,
+  and,
+  but
 } = require("./resolveStepDefinition");
 
 window.defineParameterType = defineParameterType;
 window.when = when;
 window.then = then;
 window.given = given;
+window.and = and;
+window.but = but;
 window.cy = {
   log: jest.fn()
 };
@@ -120,5 +124,13 @@ describe("Smart tagging", () => {
 
   createTestsFromFeature(
     readAndParseFeatureFile("./cypress/integration/SmartTagging.feature")
+  );
+});
+
+describe("And and But", () => {
+  require("../cypress/support/step_definitions/and_and_but_steps");
+
+  createTestsFromFeature(
+    readAndParseFeatureFile("./cypress/integration/AndAndButSteps.feature")
   );
 });

--- a/resolveStepDefinition.js
+++ b/resolveStepDefinition.js
@@ -3,6 +3,8 @@ const {
   given,
   when,
   then,
+  and,
+  but,
   defineParameterType
 } = require("./lib/resolveStepDefinition");
 
@@ -17,5 +19,7 @@ module.exports = {
   Given: given,
   When: when,
   Then: then,
+  And: and,
+  But: but,
   defineParameterType
 };

--- a/steps.js
+++ b/steps.js
@@ -5,6 +5,8 @@ const {
   given,
   when,
   then,
+  and,
+  but,
   defineParameterType
 } = require("./lib/resolveStepDefinition");
 
@@ -12,8 +14,12 @@ module.exports = {
   given,
   when,
   then,
+  and,
+  but,
   Given: given,
   When: when,
   Then: then,
+  And: and,
+  But: but,
   defineParameterType
 };


### PR DESCRIPTION
I added support for and() and but() step definition to close this little gap from #82 

I'm not a master in the node/npm space. So i was not able to get the tests run, because the tests are pointing to an "installed" cypress-cucumber-prepocessor, and not to the source itself.

i've gut the jest test running (change some require temporarily) but was not able to run the cypress test. So please keep that in mind (in the meantime i saw the circle ci will take care of that).