### PR TITLE
Bold console.log when logging each step

### DIFF
--- a/lib/cukejson/cucumberDataCollector.js
+++ b/lib/cukejson/cucumberDataCollector.js
@@ -21,7 +21,7 @@ class CucumberDataCollector {
       Cypress.log({
         name: "step",
         displayName: step.keyword,
-        message: `${step.text}`,
+        message: `**${step.text}**`,
         consoleProps: () => ({ feature: this.uri, step })
       });
     };


### PR DESCRIPTION
I found this to be pretty useful when trying to pinpoint where each step actually happens in my logs. Otherwise I find that the LOG of each step gets lost amongst all of the other logs a bit. Figured I'd open this PR if other people found this useful and wanted to incorporate it as a feature. 

![shape](https://user-images.githubusercontent.com/318100/58354296-d8574b00-7e25-11e9-8126-487c0caf521f.jpg)
