### PR TITLE
Adds defineStep method

### DIFF
--- a/cypress/integration/DefineStep.feature
+++ b/cypress/integration/DefineStep.feature
@@ -1,0 +1,4 @@
+Feature: Using defineStep
+  Scenario: Should be able to use steps defined with defineStep
+    When I set the value to 2
+    Then The value equals 2

--- a/cypress/support/step_definitions/usingDefineSteps.js
+++ b/cypress/support/step_definitions/usingDefineSteps.js
@@ -1,0 +1,11 @@
+/* global defineStep */
+
+let storedValue = 0;
+
+defineStep("I set the value to {int}", value => {
+  storedValue = value;
+});
+
+defineStep("The value equals {int}", expectedValue => {
+  expect(storedValue).to.equal(expectedValue);
+});

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -6,13 +6,14 @@ const { getStepDefinitionsPaths } = require("./getStepDefinitionsPaths");
 // feature file
 const createCucumber = (spec, toRequire) =>
   `
-  const {resolveAndRunStepDefinition, defineParameterType, given, when, then, and, but} = require('cypress-cucumber-preprocessor/lib/resolveStepDefinition');
+  const {resolveAndRunStepDefinition, defineParameterType, given, when, then, and, but, defineStep} = require('cypress-cucumber-preprocessor/lib/resolveStepDefinition');
   const Given = window.Given = window.given = given;
   const When = window.When = window.when = when;
   const Then = window.Then = window.then = then;
   const And = window.And = window.and = and;
   const But = window.But = window.but = but;
   window.defineParameterType = defineParameterType;
+  window.defineStep = defineStep;
   const { createTestsFromFeature } = require('cypress-cucumber-preprocessor/lib/createTestsFromFeature');
   ${eval(toRequire).join("\n")}
   const {Parser, Compiler} = require('gherkin');

--- a/lib/resolveStepDefinition.js
+++ b/lib/resolveStepDefinition.js
@@ -138,5 +138,8 @@ module.exports = {
   but: (expression, implementation) => {
     stepDefinitionRegistry.runtime(expression, implementation);
   },
+  defineStep: (expression, implementation) => {
+    stepDefinitionRegistry.runtime(expression, implementation);
+  },
   defineParameterType: defineParameterType(stepDefinitionRegistry)
 };

--- a/lib/resolveStepDefinition.test.js
+++ b/lib/resolveStepDefinition.test.js
@@ -5,6 +5,7 @@ const { Parser } = require("gherkin");
 const { createTestsFromFeature } = require("./createTestsFromFeature");
 const {
   defineParameterType,
+  defineStep,
   when,
   then,
   given,
@@ -18,6 +19,7 @@ window.then = then;
 window.given = given;
 window.and = and;
 window.but = but;
+window.defineStep = defineStep;
 window.cy = {
   log: jest.fn()
 };
@@ -132,5 +134,13 @@ describe("And and But", () => {
 
   createTestsFromFeature(
     readAndParseFeatureFile("./cypress/integration/AndAndButSteps.feature")
+  );
+});
+
+describe("defineStep", () => {
+  require("../cypress/support/step_definitions/usingDefineSteps");
+
+  createTestsFromFeature(
+    readAndParseFeatureFile("./cypress/integration/DefineStep.feature")
   );
 });

--- a/steps.js
+++ b/steps.js
@@ -7,7 +7,8 @@ const {
   then,
   and,
   but,
-  defineParameterType
+  defineParameterType,
+  defineStep
 } = require("./lib/resolveStepDefinition");
 
 module.exports = {
@@ -21,5 +22,6 @@ module.exports = {
   Then: then,
   And: and,
   But: but,
-  defineParameterType
+  defineParameterType,
+  defineStep
 };


### PR DESCRIPTION
As a step could be used with different keywords, like Given and When for example, defineStep will allow to create a step without linking it to a unique keyword in the code.

Related to https://github.com/TheBrainFamily/cypress-cucumber-preprocessor/issues/172.