### PR TITLE
resourcePath no longer passed into loader from webpack correctly

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -25,7 +25,7 @@ const createCucumber = (filePath, cucumberJson, spec, toRequire) =>
   createTestsFromFeature(filePath, spec);
   `;
 
-module.exports = (spec, filePath = this.resourcePath) => {
+module.exports = function(spec, filePath = this.resourcePath) {
   const explorer = cosmiconfig("cypress-cucumber-preprocessor", { sync: true });
   const loaded = explorer.load();
   const cucumberJson =


### PR DESCRIPTION
partial fix for https://github.com/TheBrainFamily/cypress-cucumber-preprocessor/issues/192

Accidentally changed the loader function definition with the cucumber.json PR - revert to previous way it was called to sort out the 'this' resolution when called from webpack.

**Note**: there are still issues with the typescript webpack example due to the use of the jsonFormatter module browser side

To fix this and get the typescript webpack example running again I had to identify some modules in the webpack config in that example as empty

```
module.exports = {
  resolve: {
    extensions: [".ts", ".js"]
  },
  node: { fs: "empty", child_process: "empty", readline: "empty" },  <--- fixes the webpack example
  module: {
    rules: [
      {
        test: /\.ts$/,
        exclude: [/node_modules/],
        use: [
          {
            loader: "ts-loader"
          }
        ]
      },
      {
        test: /\.feature$/,
        use: [
          {
            loader: "cypress-cucumber-preprocessor/loader"
          }
        ]
      }
    ]
  }
};
```
see https://github.com/Asana/node-asana/issues/114#issuecomment-289156939 for discussion of this.

There may be a neater way to get the webpack loader example working again without this addition


