### PR TITLE
Remove the text/plain error attachment from the cucumber report

### DIFF
--- a/lib/cukejson/cucumberDataCollector.js
+++ b/lib/cukejson/cucumberDataCollector.js
@@ -70,17 +70,10 @@ class CucumberDataCollector {
           duration: this.timeTaken()
         };
       } else {
-        const attachment = {
-          index: this.currentStep,
-          testCase: this.formatTestCase(this.currentScenario),
-          data: btoa(err.message.toString()),
-          media: { type: "text/plain" }
-        };
         this.stepResults[this.currentStep] = {
           status: statuses.FAILED,
           duration: this.timeTaken(),
-          exception: this.testError,
-          attachment
+          exception: this.testError
         };
       }
       this.onFinishScenario(this.currentScenario);


### PR DESCRIPTION
This is added in addition to the stack trace when an error is thrown.

Adds no value and crashes on non latin text.

Fixes https://github.com/TheBrainFamily/cypress-cucumber-preprocessor/issues/221