### PR TITLE
feat(getstepdefinitionspaths): configurable nonGlobalStepDefinitions base directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,9 @@ Please make use of [cosmiconfig](https://github.com/davidtheclark/cosmiconfig) t
 
 Option | Default value | Description
 ------------ | ------------- | -------------
-commonPath | `cypress/integration/common` when `nonGlobalStepDefinitions` is true <br> `cypress/support/step_definitions` when `nonGlobalStepDefinitions` is false | Define the path to a folder containing all common step definitions of your tests
-nonGlobalStepDefinitions | false | If true use the Cypress Cucumber Preprocessor Style pattern for placing step definitions files. If false, we will use the "oldschool" (everything is global) Cucumber style
+commonPath | `cypress/integration/common` when `nonGlobalStepDefinitions` is true <br> `cypress/support/step_definitions` when `nonGlobalStepDefinitions` is false <br> `${nonGlobalStepBaseDir}/common` when `nonGlobalStepBaseDir` is defined | Define the path to a folder containing all common step definitions of your tests. When `nonGlobalStepBaseDir` is defined this path is defined from that base location. e.g `${nonGlobalStepBaseDir}/${commonPath}`.
+nonGlobalStepDefinitions | false | If true use the Cypress Cucumber Preprocessor Style pattern for placing step definitions files. If false, we will use the "oldschool" (everything is global) Cucumber style.
+nonGlobalStepBaseDir| undefined | If defined and `nonGlobalStepDefinitions` is also true then step definition searches for folders with the features name will start from the directory provided here. The cwd is already taken into account. e.g `test/step_definitions`.
 stepDefinitions | `cypress/integration` when `nonGlobalStepDefinitions` is true <br> `cypress/support/step_definitions` when `nonGlobalStepDefinitions` is false | Path to the folder containing our step definitions.
 
 ## How to organize the tests

--- a/lib/getStepDefinitionsPaths.js
+++ b/lib/getStepDefinitionsPaths.js
@@ -1,23 +1,35 @@
 const glob = require("glob");
 const cosmiconfig = require("cosmiconfig");
+const process = require("process");
 const stepDefinitionPath = require("./stepDefinitionPath.js");
 const { getStepDefinitionPathsFrom } = require("./getStepDefinitionPathsFrom");
 
 const getStepDefinitionsPaths = filePath => {
   let paths = [];
+  const featureBase = stepDefinitionPath();
+  const appRoot = process.cwd();
   const explorer = cosmiconfig("cypress-cucumber-preprocessor", { sync: true });
   const loaded = explorer.load();
   if (loaded && loaded.config && loaded.config.nonGlobalStepDefinitions) {
-    const nonGlobalPattern = `${getStepDefinitionPathsFrom(
-      filePath
-    )}/**/*.+(js|ts)`;
-    const commonPath =
-      loaded.config.commonPath || `${stepDefinitionPath()}/common/`;
+    let nonGlobalPath = getStepDefinitionPathsFrom(filePath);
+    let commonPath = loaded.config.commonPath || `${featureBase}/common/`;
+
+    if (loaded.config.nonGlobalStepBaseDir) {
+      const stepBase = `${appRoot}/${loaded.config.nonGlobalStepBaseDir}`;
+      nonGlobalPath = nonGlobalPath.replace(featureBase, stepBase);
+      commonPath = `${nonGlobalPath}/${loaded.config.commonPath ||
+        `${stepBase}/common/`}`;
+    }
+
+    const nonGlobalPattern = `${nonGlobalPath}/**/*.+(js|ts)`;
     const commonDefinitionsPattern = `${commonPath}**/*.+(js|ts)`;
-    paths = paths.concat(glob.sync(nonGlobalPattern));
-    paths = paths.concat(glob.sync(commonDefinitionsPattern));
+
+    paths = paths.concat(
+      glob.sync(nonGlobalPattern),
+      glob.sync(commonDefinitionsPattern)
+    );
   } else {
-    const pattern = `${stepDefinitionPath()}/**/*.+(js|ts)`;
+    const pattern = `${featureBase}/**/*.+(js|ts)`;
     paths = paths.concat(glob.sync(pattern));
   }
   return paths;

--- a/lib/getStepDefinitionsPaths.test.js
+++ b/lib/getStepDefinitionsPaths.test.js
@@ -5,6 +5,10 @@ jest.mock("glob", () => ({
   }
 }));
 
+jest.mock("process", () => ({
+  cwd: () => "cwd"
+}));
+
 describe("getStepDefinitionsPaths", () => {
   it("should return the default common folder", () => {
     jest.resetModules();
@@ -40,5 +44,43 @@ describe("getStepDefinitionsPaths", () => {
     const expected = "myPath/**/*.+(js|ts)";
 
     expect(actual).to.include(expected);
+  });
+
+  it("should return the default non global step definition pattern", () => {
+    jest.resetModules();
+    jest.mock("cosmiconfig", () => () => ({
+      load: () => ({
+        config: {
+          nonGlobalStepDefinitions: true
+        }
+      })
+    }));
+    // eslint-disable-next-line global-require
+    const { getStepDefinitionsPaths } = require("./getStepDefinitionsPaths");
+    const path = "stepDefinitionPath/test.feature";
+    const actual = getStepDefinitionsPaths(path);
+    const expected = "stepDefinitionPath/test/**/*.+(js|ts)";
+
+    expect(actual).to.include(expected);
+  });
+
+  it("should return the overriden non global step definition pattern if nonGlobalStepBaseDir is defined", () => {
+    jest.resetModules();
+    jest.mock("cosmiconfig", () => () => ({
+      load: () => ({
+        config: {
+          nonGlobalStepDefinitions: true,
+          nonGlobalStepBaseDir: "nonGlobalStepBaseDir"
+        }
+      })
+    }));
+    // eslint-disable-next-line global-require
+    const { getStepDefinitionsPaths } = require("./getStepDefinitionsPaths");
+    const path = "stepDefinitionPath/test.feature";
+    const actual = getStepDefinitionsPaths(path);
+    const expected = "cwd/nonGlobalStepBaseDir/test/**/*.+(js|ts)";
+
+    expect(actual).to.include(expected);
+    expect(actual).to.not.include("stepDefinitionPath/test/**/*.+(js|ts)");
   });
 });


### PR DESCRIPTION
Within my team we have a preference to split the step definitions away from where the feature files are located.

However we love the ability to scope test definitions so using the common folder and global approach doesn't seem right.

To this end I have created a PR that if you agree adds a new configuration option `nonGlobalStepBaseDir` which defines a location from which the feature files folders are matched from. If it is not set then the current behaviour is maintained.