### PR TITLE
fix(getstepdefinitionspaths): custom commonPath

### DIFF
--- a/lib/getStepDefinitionsPaths.js
+++ b/lib/getStepDefinitionsPaths.js
@@ -4,13 +4,19 @@ const stepDefinitionPath = require("./stepDefinitionPath.js");
 const { getStepDefinitionPathsFrom } = require("./getStepDefinitionPathsFrom");
 
 const getStepDefinitionsPaths = filePath => {
+  const appRoot = process.cwd();
   let paths = [];
   const config = getConfig();
   if (config && config.nonGlobalStepDefinitions) {
     const nonGlobalPattern = `${getStepDefinitionPathsFrom(
       filePath
     )}/**/*.+(js|ts)`;
-    const commonPath = config.commonPath || `${stepDefinitionPath()}/common/`;
+
+    let commonPath = config.commonPath || `${stepDefinitionPath()}/common/`;
+
+    if (config.commonPath) {
+      commonPath = `${appRoot}/${commonPath}`;
+    }
     const commonDefinitionsPattern = `${commonPath}**/*.+(js|ts)`;
     paths = paths.concat(glob.sync(nonGlobalPattern));
     paths = paths.concat(glob.sync(commonDefinitionsPattern));

--- a/lib/getStepDefinitionsPaths.test.js
+++ b/lib/getStepDefinitionsPaths.test.js
@@ -23,8 +23,13 @@ describe("getStepDefinitionsPaths", () => {
 
     expect(actual).to.include(expected);
   });
+
   it("should return the common folder defined by the developper", () => {
     jest.resetModules();
+
+    jest.mock("fs");
+    jest.spyOn(process, "cwd").mockImplementation(() => "cwd");
+
     jest.mock("cosmiconfig", () => () => ({
       load: () => ({
         config: {
@@ -37,7 +42,7 @@ describe("getStepDefinitionsPaths", () => {
     const { getStepDefinitionsPaths } = require("./getStepDefinitionsPaths");
 
     const actual = getStepDefinitionsPaths("/path");
-    const expected = "myPath/**/*.+(js|ts)";
+    const expected = "cwd/myPath/**/*.+(js|ts)";
 
     expect(actual).to.include(expected);
   });


### PR DESCRIPTION
This PR fix the path of global step definitions path configured in the package.json.
Without this the generated path is relative and the library can't js files under my custom path.