### PR TITLE
fix(tags): adding conditions to avoid features running if no matching tags are found

### DIFF
--- a/cypress-tags.js
+++ b/cypress-tags.js
@@ -57,7 +57,9 @@ paths.forEach(featurePath => {
 try {
   if (featuresToRun.length || envTags === "") {
     execFileSync(
-      `${__dirname}/../.bin/cypress`,
+      process.platform === "win32"
+        ? `${__dirname}/../.bin/cypress.cmd`
+        : `${__dirname}/../.bin/cypress`,
       [...process.argv.slice(2), "--spec", featuresToRun.join(",")],
       {
         stdio: [process.stdin, process.stdout, process.stderr]

--- a/cypress-tags.js
+++ b/cypress-tags.js
@@ -55,15 +55,18 @@ paths.forEach(featurePath => {
 });
 
 try {
-  execFileSync(
-    process.platform === "win32"
-      ? `${__dirname}/../.bin/cypress.cmd`
-      : `${__dirname}/../.bin/cypress`,
-    [...process.argv.slice(2), "--spec", featuresToRun.join(",")],
-    {
-      stdio: [process.stdin, process.stdout, process.stderr]
-    }
-  );
+  if (featuresToRun.length || envTags === "") {
+    execFileSync(
+      `${__dirname}/../.bin/cypress`,
+      [...process.argv.slice(2), "--spec", featuresToRun.join(",")],
+      {
+        stdio: [process.stdin, process.stdout, process.stderr]
+      }
+    );
+  } else {
+    console.log("No matching tags found");
+    process.exit(0);
+  }
 } catch (e) {
   debug("Error while running cypress (or just a test failure)", e);
   process.exit(1);


### PR DESCRIPTION
Adding conditions to avoid features running if no matching tags are found. 

Currently, if I run `./node_modules/.bin/cypress-tags run -e TAGS='@undefined-tag'`, with `@undefined-tag` absent from every .feature file, all the features all launched : 

See line 61 of cypress-tags.js :
```js
[...process.argv.slice(2), "--spec", featuresToRun.join(",")]
```
Currently, if there are no matching features found, `featuresToRun.join(",")` returns empty string, so features are not filtered.