### PR TITLE
feat(tags): improve the tags behavior, to base on cypress configuration

### DIFF
--- a/cypress-tags.js
+++ b/cypress-tags.js
@@ -2,7 +2,6 @@
 
 const { Parser } = require("gherkin");
 const glob = require("glob");
-const path = require("path");
 const fs = require("fs");
 const { execFileSync } = require("child_process");
 
@@ -40,7 +39,7 @@ let usingCypressConf = true;
 try {
   // TODO : curently we don't allow the override of the cypress.json path
   // maybe we can set this path in the plugin conf (package.json : "cypressConf": "test/cypress.json")
-  const cypressConf = JSON.parse(fs.readFileSync(path.resolve("cypress.json")));
+  const cypressConf = require("../../cypress.json");
   const integrationFolder =
     cypressConf && cypressConf.integrationFolder
       ? cypressConf.integrationFolder.replace(/\/$/, "")
@@ -55,7 +54,8 @@ try {
       ? cypressConf.testFiles.split(",")
       : cypressConf.testFiles;
     testFiles = testFiles.map(pattern => `${integrationFolder}/${pattern}`);
-    defaultGlob = `{${testFiles.join(",")}}`;
+    defaultGlob =
+      testFiles.length > 1 ? `{${testFiles.join(",")}}` : testFiles[0];
   } else {
     defaultGlob = `${integrationFolder}/**/*.feature`;
   }

--- a/cypress-tags.js
+++ b/cypress-tags.js
@@ -28,49 +28,50 @@ function parseArgsOrDefault(argPrefix, defaultValue) {
 }
 
 const envGlob = parseArgsOrDefault("GLOB", false);
-debug("Found glob", envGlob);
 const envTags = parseArgsOrDefault("TAGS", "");
-debug("Found tag expression", envTags);
 
-let defaultGlob = "cypress/integration/**/*.feature";
+let specGlob = envGlob || "cypress/integration/**/*.feature";
 let ignoreGlob = "";
-let usingCypressConf = true;
+let usingCypressConf = false;
 
-try {
-  // TODO : curently we don't allow the override of the cypress.json path
-  // maybe we can set this path in the plugin conf (package.json : "cypressConf": "test/cypress.json")
-  const cypressConf = require("../../cypress.json");
-  const integrationFolder =
-    cypressConf && cypressConf.integrationFolder
-      ? cypressConf.integrationFolder.replace(/\/$/, "")
-      : "cypress/integration";
+if (!envGlob) {
+  try {
+    // TODO : curently we don't allow the override of the cypress.json path
+    // maybe we can set this path in the plugin conf (package.json : "cypressConf": "test/cypress.json")
+    // eslint-disable-next-line import/no-unresolved,global-require
+    const cypressConf = require("../../cypress.json");
+    const integrationFolder =
+      cypressConf && cypressConf.integrationFolder
+        ? cypressConf.integrationFolder.replace(/\/$/, "")
+        : "cypress/integration";
 
-  if (cypressConf && cypressConf.ignoreTestFiles) {
-    ignoreGlob = cypressConf.ignoreTestFiles;
+    if (cypressConf && cypressConf.ignoreTestFiles) {
+      ignoreGlob = cypressConf.ignoreTestFiles;
+    }
+
+    if (cypressConf && cypressConf.testFiles) {
+      let testFiles = !Array.isArray(cypressConf.testFiles)
+        ? cypressConf.testFiles.split(",")
+        : cypressConf.testFiles;
+      testFiles = testFiles.map(pattern => `${integrationFolder}/${pattern}`);
+      specGlob =
+        testFiles.length > 1 ? `{${testFiles.join(",")}}` : testFiles[0];
+    } else {
+      specGlob = `${integrationFolder}/**/*.feature`;
+    }
+    console.log("Using cypress.json configuration:");
+    console.log("Spec files: ", specGlob);
+    if (ignoreGlob) console.log("Ignored files: ", ignoreGlob);
+  } catch (err) {
+    usingCypressConf = false;
+    specGlob = "cypress/integration/**/*.feature";
+    console.log("Failed to read cypress.json, using default configuration");
+    console.log("Spec files: ", specGlob);
   }
-
-  if (cypressConf && cypressConf.testFiles) {
-    let testFiles = !Array.isArray(cypressConf.testFiles)
-      ? cypressConf.testFiles.split(",")
-      : cypressConf.testFiles;
-    testFiles = testFiles.map(pattern => `${integrationFolder}/${pattern}`);
-    defaultGlob =
-      testFiles.length > 1 ? `{${testFiles.join(",")}}` : testFiles[0];
-  } else {
-    defaultGlob = `${integrationFolder}/**/*.feature`;
-  }
-} catch (err) {
-  usingCypressConf = false;
-  defaultGlob = "cypress/integration/**/*.feature";
 }
 
-if (envGlob) usingCypressConf = false; // in this case, we ignore the Cypress conf
-
-const specGlob = envGlob ? envGlob.replace(/.*=/, "") : defaultGlob;
-
-if (envGlob) {
-  debug("Found glob", specGlob);
-}
+debug("Found glob", specGlob);
+debug("Found tag expression", envTags);
 
 const paths = glob
   .sync(specGlob, {

--- a/cypress-tags.js
+++ b/cypress-tags.js
@@ -2,6 +2,7 @@
 
 const { Parser } = require("gherkin");
 const glob = require("glob");
+const path = require("path");
 const fs = require("fs");
 const { execFileSync } = require("child_process");
 
@@ -27,17 +28,56 @@ function parseArgsOrDefault(argPrefix, defaultValue) {
   return argValue !== "" ? argValue : defaultValue;
 }
 
-// TODO currently we only work with feature files in cypress/integration folder.
-// It should be easy to base this on the cypress.json configuration - we are happy to take a PR
-// here if you need this functionality!
-const defaultGlob = "cypress/integration/**/*.feature";
-
-const specGlob = parseArgsOrDefault("GLOB", defaultGlob);
-debug("Found glob", specGlob);
+const envGlob = parseArgsOrDefault("GLOB", false);
+debug("Found glob", envGlob);
 const envTags = parseArgsOrDefault("TAGS", "");
 debug("Found tag expression", envTags);
 
-const paths = glob.sync(specGlob);
+let defaultGlob = "cypress/integration/**/*.feature";
+let ignoreGlob = "";
+let usingCypressConf = true;
+
+try {
+  // TODO : curently we don't allow the override of the cypress.json path
+  // maybe we can set this path in the plugin conf (package.json : "cypressConf": "test/cypress.json")
+  const cypressConf = JSON.parse(fs.readFileSync(path.resolve("cypress.json")));
+  const integrationFolder =
+    cypressConf && cypressConf.integrationFolder
+      ? cypressConf.integrationFolder.replace(/\/$/, "")
+      : "cypress/integration";
+
+  if (cypressConf && cypressConf.ignoreTestFiles) {
+    ignoreGlob = cypressConf.ignoreTestFiles;
+  }
+
+  if (cypressConf && cypressConf.testFiles) {
+    let testFiles = !Array.isArray(cypressConf.testFiles)
+      ? cypressConf.testFiles.split(",")
+      : cypressConf.testFiles;
+    testFiles = testFiles.map(pattern => `${integrationFolder}/${pattern}`);
+    defaultGlob = `{${testFiles.join(",")}}`;
+  } else {
+    defaultGlob = `${integrationFolder}/**/*.feature`;
+  }
+} catch (err) {
+  usingCypressConf = false;
+  defaultGlob = "cypress/integration/**/*.feature";
+}
+
+if (envGlob) usingCypressConf = false; // in this case, we ignore the Cypress conf
+
+const specGlob = envGlob ? envGlob.replace(/.*=/, "") : defaultGlob;
+
+if (envGlob) {
+  debug("Found glob", specGlob);
+}
+
+const paths = glob
+  .sync(specGlob, {
+    nodir: true,
+    ignore: usingCypressConf ? ignoreGlob : ""
+  })
+  .filter(pathName => pathName.endsWith(".feature"));
 
 const featuresToRun = [];
 


### PR DESCRIPTION
BREAKING CHANGE: Glob pattern is no longer "cypress/integration/**/*.feature", but is now based on cypress.json configuration by default, and takes into account the ignoreTestFiles

(fallback to cypress/integration/**/*.feature if there is any error)

If the GLOB option is specified, Cypress configuration will be ignored, and the features will only match this option.