### PR TITLE
Always run Cucumber After hooks, even if the scenario fails #248

### DIFF
--- a/cypress/integration/BeforeAndAfterSteps.feature
+++ b/cypress/integration/BeforeAndAfterSteps.feature
@@ -30,3 +30,22 @@ Scenario: With multiple tags
     Given I executed empty step
     Then Tagged Before was called twice
     And Untagged Before was called once
+
+# After is tested in following scenario by verifying that the After ran at the end of the previous one
+# Even though the previous one failed - commented because can't have tests that fail in the suite
+Scenario: After runs after test failure part 1
+    Given I executed empty step
+    # And An error happens
+    And I executed empty step
+
+Scenario: After runs after test failure part 2
+    Then Flag should be set by untagged After
+
+# After is tested in following scenario by verifying that the After ran at the end of the previous one
+# Even though the previous one failed in the Before block - commented because can't have tests that fail in the suite
+#@errorInBefore
+Scenario: After runs after Before failure part 1
+    Given I executed empty step
+
+Scenario: After runs after Before failure part 2
+    Then Flag should be set by untagged After

--- a/cypress/support/step_definitions/before_and_after_steps.js
+++ b/cypress/support/step_definitions/before_and_after_steps.js
@@ -29,6 +29,10 @@ Before({ tags: "@willNeverRun" }, () => {
   throw new Error("XXX: before hook unexpectedly called.");
 });
 
+Before({ tags: "@errorInBefore" }, () => {
+  throw new Error("Before hook exception.");
+});
+
 After({ tags: "@willNeverRun" }, () => {
   throw new Error("XXX: after hook unexpectedly called.");
 });

--- a/cypress/support/step_definitions/before_and_after_steps.js
+++ b/cypress/support/step_definitions/before_and_after_steps.js
@@ -71,3 +71,7 @@ Then("Flag should be set by untagged After", () => {
 Then("Flag should be set by tagged After", () => {
   expect(flagSetByTaggedAfter).to.equal(true);
 });
+
+Then("An error happens", () => {
+  expect(true).to.equal(false);
+});

--- a/lib/createTestFromScenario.js
+++ b/lib/createTestFromScenario.js
@@ -15,17 +15,21 @@ const replaceParameterTags = (rowData, text) =>
 
 // eslint-disable-next-line func-names
 const stepTest = function(state, stepDetails, exampleRowData) {
-  cy.then(() => state.onStartStep(stepDetails))
-    .then(() =>
-      resolveAndRunStepDefinition.call(
-        this,
-        stepDetails,
-        replaceParameterTags,
-        exampleRowData,
-        state.feature.name
-      )
-    )
-    .then(() => state.onFinishStep(stepDetails, statuses.PASSED));
+  state.onStartStep(stepDetails);
+  try {
+    resolveAndRunStepDefinition.call(
+      this,
+      stepDetails,
+      replaceParameterTags,
+      exampleRowData,
+      state.feature.name
+    );
+    state.onFinishStep(stepDetails, statuses.PASSED);
+    return Cypress.Promise.resolve();
+  } catch (e) {
+    state.onFinishStep(stepDetails, statuses.FAILED);
+    return Cypress.Promise.reject(e);
+  }
 };
 
 const runTest = (scenario, stepsToRun, rowData) => {
@@ -42,12 +46,26 @@ const runTest = (scenario, stepsToRun, rowData) => {
         resolveAndRunBeforeHooks.call(this, scenario.tags, state.feature.name)
       )
       .then(() =>
-        indexedSteps.forEach(step => stepTest.call(this, state, step, rowData))
-      )
-      .then(() =>
-        resolveAndRunAfterHooks.call(this, scenario.tags, state.feature.name)
-      )
-      .then(() => state.onFinishScenario(scenario));
+        Cypress.Promise.each(indexedSteps, step =>
+          stepTest.call(this, state, step, rowData)
+        )
+          .then(() => {
+            resolveAndRunAfterHooks.call(
+              this,
+              scenario.tags,
+              state.feature.name
+            );
+            state.onFinishScenario(scenario);
+          })
+          .catch(err => {
+            resolveAndRunAfterHooks.call(
+              this,
+              scenario.tags,
+              state.feature.name
+            );
+            return Cypress.Promise.reject(err);
+          })
+      );
   });
 };
 

--- a/lib/createTestFromScenario.js
+++ b/lib/createTestFromScenario.js
@@ -45,26 +45,28 @@ const runTest = (scenario, stepsToRun, rowData) => {
       .then(() =>
         resolveAndRunBeforeHooks.call(this, scenario.tags, state.feature.name)
       )
-      .then(() =>
-        Cypress.Promise.each(indexedSteps, step =>
-          stepTest.call(this, state, step, rowData)
-        )
-          .then(() => {
-            resolveAndRunAfterHooks.call(
-              this,
-              scenario.tags,
-              state.feature.name
-            );
-            state.onFinishScenario(scenario);
-          })
-          .catch(err => {
-            resolveAndRunAfterHooks.call(
-              this,
-              scenario.tags,
-              state.feature.name
-            );
-            return Cypress.Promise.reject(err);
-          })
+      .then(beforeErr =>
+        beforeErr instanceof Error
+          ? Cypress.Promise.reject(beforeErr)
+          : Cypress.Promise.each(indexedSteps, step =>
+              stepTest.call(this, state, step, rowData)
+            )
+              .then(() => {
+                resolveAndRunAfterHooks.call(
+                  this,
+                  scenario.tags,
+                  state.feature.name
+                );
+                state.onFinishScenario(scenario);
+              })
+              .catch(stepErr => {
+                resolveAndRunAfterHooks.call(
+                  this,
+                  scenario.tags,
+                  state.feature.name
+                );
+                return Cypress.Promise.reject(stepErr);
+              })
       );
   });
 };

--- a/lib/testHelpers/setupTestFramework.js
+++ b/lib/testHelpers/setupTestFramework.js
@@ -9,7 +9,11 @@ window.Cypress = {
   on: jest.fn(),
   off: jest.fn(),
   log: jest.fn(),
-  Promise: { each: (iterator, iteree) => iterator.map(iteree) }
+  Promise: {
+    each: (iterator, iteree) =>
+      new Promise(resolve => resolve(iterator.map(iteree))),
+    reject: jest.fn()
+  }
 };
 
 const {
@@ -25,8 +29,8 @@ const {
 } = require("../resolveStepDefinition");
 
 const mockedPromise = func => {
-  func();
-  return { then: mockedPromise };
+  const val = func();
+  return new Promise(resolve => resolve(val));
 };
 
 window.defineParameterType = defineParameterType;


### PR DESCRIPTION
Fixes issue https://github.com/TheBrainFamily/cypress-cucumber-preprocessor/issues/248

In `createTestFromScenario` `runTest` function wrap the call of the scenario steps in promises. Catch the reject failures from both the Before Hooks and the Steps and then run the After Hooks before throwing the Error and failing the scenario.

Added scenarios to the BeforeAndAfterStep.feature to show that After is still called if there is an error thrown - commented out tests as cannot have test failures in the suite.

Fixed `setupTestFramework` to reflect the added promises