### PR TITLE
Add option for cypress-tags to use globally installed cypress version

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,12 @@ Example:
   ./node_modules/.bin/cypress-tags run -e TAGS='not @foo and (@bar or @zap)'
 ```
 
+You can also pass the option GLOBAL_CYPRESS=true to use the globaly installed cypress version.
+Example
+```shell
+  ./node_modules/.bin/cypress-tags run -e TAGS='not @foo and (@bar or @zap)' -e GLOBAL_CYPRESS=true
+```
+
 Please note - we use our own cypress-tags wrapper to speed things up.
 For more details and examples please take a look to the [example repo](https://github.com/TheBrainFamily/cypress-cucumber-example).
 

--- a/cypress-tags.js
+++ b/cypress-tags.js
@@ -34,6 +34,11 @@ const found = process.argv.slice(2).find(arg => arg.indexOf("TAGS=") === 0);
 const envTags = found ? found.replace(/.*=/, "") : "";
 debug("Found tag expression", envTags);
 
+// useful when using cypress/included dockerimage
+const useGloballyInstalledCypress = process.argv.includes(
+  "GLOBAL_CYPRESS=true"
+);
+
 paths.forEach(featurePath => {
   const spec = `${fs.readFileSync(featurePath)}`;
   const parsedFeature = new Parser().parse(spec);
@@ -61,10 +66,16 @@ paths.forEach(featurePath => {
 
 try {
   if (featuresToRun.length || envTags === "") {
-    execFileSync(
+    const systemSpecificCommand =
       process.platform === "win32"
         ? `cypress.cmd`
-        : `${__dirname}/../.bin/cypress`,
+        : `${__dirname}/../.bin/cypress`;
+    const command = useGloballyInstalledCypress
+      ? "cypress"
+      : systemSpecificCommand;
+
+    execFileSync(
+      command,
       [...process.argv.slice(2), "--spec", featuresToRun.join(",")],
       {
         stdio: [process.stdin, process.stdout, process.stderr]


### PR DESCRIPTION
Add cypress-tags "-e GLOBAL_CYPRESS=true" option to use globally installed cypress. This is useful if you want to enhance pipeline speed by using cypress/included dockerimages. At our company we sped up the pipeline 6x by using this image.