### PR TITLE
add typescript install type definitions to doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,14 @@ Note, that unlike WebStorm which will correctly identify multiple implementation
 
 ## TypeScript Support
 
+### Install
+
+Install the plug-in type definitions:
+
+```shell
+npm install --save-dev @types/cypress-cucumber-preprocessor
+```
+
 ### With Webpack
 You can also use a Webpack loader to process feature files (TypeScript supported). To see how it is done please take 
 a look here: [cypress-cucumber-webpack-typescript-example](https://github.com/TheBrainFamily/cypress-cucumber-webpack-typescript-example)


### PR DESCRIPTION
What's new ?
Add a subsection in the documentation section of typescript to explain the user that he have to install typescript plugin types.

Feel free to edit/not merge... :-)

Have a nice day.