### PR TITLE
feat: add support for custom step timeout

### DIFF
--- a/lib/createTestFromScenario.js
+++ b/lib/createTestFromScenario.js
@@ -1,6 +1,7 @@
 /* eslint-disable prefer-template */
 const statuses = require("cucumber/lib/status").default;
 const {
+  resolveStepDefinition,
   resolveAndRunStepDefinition,
   resolveAndRunBeforeHooks,
   resolveAndRunAfterHooks
@@ -15,8 +16,13 @@ const replaceParameterTags = (rowData, text) =>
 
 // eslint-disable-next-line func-names
 const stepTest = function(state, stepDetails, exampleRowData) {
+  const step = resolveStepDefinition.call(
+    this,
+    stepDetails,
+    state.feature.name
+  );
   cy.then(() => state.onStartStep(stepDetails))
-    .then(() =>
+    .then((step && step.config) || {}, () =>
       resolveAndRunStepDefinition.call(
         this,
         stepDetails,

--- a/lib/resolveStepDefinition.js
+++ b/lib/resolveStepDefinition.js
@@ -18,7 +18,15 @@ class StepDefinitionRegistry {
     };
 
     this.definitions = [];
-    this.runtime = (matcher, implementation) => {
+    this.runtime = (...args) => {
+      let matcher;
+      let config;
+      let implementation;
+      if (args.length > 2) {
+        [matcher, config, implementation] = args;
+      } else {
+        [matcher, implementation] = args;
+      }
       let expression;
       if (matcher instanceof RegExp) {
         expression = new RegularExpression(
@@ -35,6 +43,7 @@ class StepDefinitionRegistry {
       this.definitions.push({
         implementation,
         expression,
+        config,
         featureName: window.currentFeatureName || "___GLOBAL_EXECUTION___"
       });
     };
@@ -178,6 +187,9 @@ function parseHookArgs(args) {
 }
 
 module.exports = {
+  resolveStepDefinition(step, featureName) {
+    return resolveStepDefinition(step, featureName);
+  },
   resolveAndRunBeforeHooks(scenarioTags, featureName) {
     return resolveAndRunHooks(beforeHookRegistry, scenarioTags, featureName);
   },
@@ -210,20 +222,20 @@ module.exports = {
     }
     throw new Error(`Step implementation missing for: ${stepText}`);
   },
-  given: (expression, implementation) => {
-    stepDefinitionRegistry.runtime(expression, implementation);
+  given: (...args) => {
+    stepDefinitionRegistry.runtime(...args);
   },
-  when: (expression, implementation) => {
-    stepDefinitionRegistry.runtime(expression, implementation);
+  when: (...args) => {
+    stepDefinitionRegistry.runtime(...args);
   },
-  then: (expression, implementation) => {
-    stepDefinitionRegistry.runtime(expression, implementation);
+  then: (...args) => {
+    stepDefinitionRegistry.runtime(...args);
   },
-  and: (expression, implementation) => {
-    stepDefinitionRegistry.runtime(expression, implementation);
+  and: (...args) => {
+    stepDefinitionRegistry.runtime(...args);
   },
-  but: (expression, implementation) => {
-    stepDefinitionRegistry.runtime(expression, implementation);
+  but: (...args) => {
+    stepDefinitionRegistry.runtime(...args);
   },
   Before: (...args) => {
     const { tags, implementation } = parseHookArgs(args);

--- a/lib/testHelpers/setupTestFramework.js
+++ b/lib/testHelpers/setupTestFramework.js
@@ -24,9 +24,18 @@ const {
   After
 } = require("../resolveStepDefinition");
 
+const mockedThen = (funcOrConfig, func) => {
+  if (typeof funcOrConfig === "object") {
+    func();
+  } else {
+    funcOrConfig();
+  }
+  return { then: mockedThen };
+};
+
 const mockedPromise = func => {
   func();
-  return { then: mockedPromise };
+  return { then: mockedThen };
 };
 
 window.defineParameterType = defineParameterType;
@@ -46,6 +55,6 @@ window.cy = {
   startStep: mockedPromise,
   finishStep: mockedPromise,
   finishTest: mockedPromise,
-  then: mockedPromise,
+  then: mockedThen,
   end: mockedPromise
 };

--- a/steps/index.d.ts
+++ b/steps/index.d.ts
@@ -1,0 +1,105 @@
+export function given(
+  expression: RegExp | string,
+  implementation: (...args: any[]) => void
+): void;
+export function when(
+  expression: RegExp | string,
+  implementation: (...args: any[]) => void
+): void;
+export function then(
+  expression: RegExp | string,
+  implementation: (...args: any[]) => void
+): void;
+export function and(
+  expression: RegExp | string,
+  implementation: (...args: any[]) => void
+): void;
+export function but(
+  expression: RegExp | string,
+  implementation: (...args: any[]) => void
+): void;
+export function given(
+  expression: RegExp | string,
+  config: { timeout?: number },
+  implementation: (...args: any[]) => void
+): void;
+export function when(
+  expression: RegExp | string,
+  config: { timeout?: number },
+  implementation: (...args: any[]) => void
+): void;
+export function then(
+  expression: RegExp | string,
+  config: { timeout?: number },
+  implementation: (...args: any[]) => void
+): void;
+export function and(
+  expression: RegExp | string,
+  config: { timeout?: number },
+  implementation: (...args: any[]) => void
+): void;
+export function but(
+  expression: RegExp | string,
+  config: { timeout?: number },
+  implementation: (...args: any[]) => void
+): void;
+export function defineStep(
+  expression: RegExp | string,
+  implementation: (...args: any[]) => void
+): void;
+export function defineParameterType(): void;
+
+// Aliased versions of the above funcs.
+export function Given(
+  expression: RegExp | string,
+  implementation: (...args: any[]) => void
+): void;
+export function When(
+  expression: RegExp | string,
+  implementation: (...args: any[]) => void
+): void;
+export function Then(
+  expression: RegExp | string,
+  implementation: (...args: any[]) => void
+): void;
+export function And(
+  expression: RegExp | string,
+  implementation: (...args: any[]) => void
+): void;
+export function But(
+  expression: RegExp | string,
+  implementation: (...args: any[]) => void
+): void;
+export function Given(
+  expression: RegExp | string,
+  config: { timeout?: number },
+  implementation: (...args: any[]) => void
+): void;
+export function When(
+  expression: RegExp | string,
+  config: { timeout?: number },
+  implementation: (...args: any[]) => void
+): void;
+export function Then(
+  expression: RegExp | string,
+  config: { timeout?: number },
+  implementation: (...args: any[]) => void
+): void;
+export function And(
+  expression: RegExp | string,
+  config: { timeout?: number },
+  implementation: (...args: any[]) => void
+): void;
+export function But(
+  expression: RegExp | string,
+  config: { timeout?: number },
+  implementation: (...args: any[]) => void
+): void;
+export function Before(
+  optionsOrImplementation: object | ((...args: any[]) => void),
+  implementation?: (...args: any[]) => void
+): void;
+export function After(
+  optionsOrImplementation: object | ((...args: any[]) => void),
+  implementation?: (...args: any[]) => void
+): void;


### PR DESCRIPTION
Add support for passing in a config param, matching the signature of cucumber-js, to set the step
timeout in cypress.

e.g.
```
Given('a long running step', { timeout: 60000 }, () => { ... });
```
It is possible to do this by calling `cy.then({timeout: 60000}, () => {...})` inside the implementation function, but that's inconsistent with [the signature for cucumberjs](https://github.com/cucumber/cucumber-js/blob/master/docs/support_files/timeouts.md#timeouts), which feels more intuitive.
