### PR TITLE
Add an issue template in an attempt to gather info more efficiently

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,28 @@
+<!-- Questions and request for general support may be closed at the maintainers
+discretion. -->
+
+<!-- Issue reports that are deemed unrelated to specifically preprocessing will
+be closed. -->
+
+### Current behavior
+
+<!-- A description including screenshots, stack traces, DEBUG logs, etc. -->
+
+### Desired behavior
+
+<!-- A clear description of what you want to happen. -->
+
+### Test code to reproduce
+
+<!-- Issues without a reproducible example or not enough information will be
+closed. -->
+
+<!-- We can only attempt to debug your issue if you provide us with a minimal
+example to reproduce the problem. This should preferably be another Git
+repository to be cloned -->
+
+### Versions
+
+* **Cypress version**:
+* **Preprocessor version**:
+* **Node version**:


### PR DESCRIPTION
Subject says it all.

Too many issues are reported with little to no possibility of reproducing the problem, at least not without significant effort.