### PR TITLE
fix: define commonPath based on nonGlobalStepBaseDir.

### DIFF
--- a/lib/getStepDefinitionsPaths.js
+++ b/lib/getStepDefinitionsPaths.js
@@ -20,7 +20,7 @@ const getStepDefinitionsPaths = filePath => {
     if (config.nonGlobalStepBaseDir) {
       const stepBase = `${appRoot}/${config.nonGlobalStepBaseDir}`;
       nonGlobalPath = nonGlobalPath.replace(stepDefinitionPath(), stepBase);
-      commonPath = `${nonGlobalPath}/../${config.commonPath || "common/"}`;
+      commonPath = `${stepBase}/${config.commonPath || "common/"}`;
     }
 
     const nonGlobalPattern = `${nonGlobalPath}/**/*.+(js|ts)`;

--- a/lib/getStepDefinitionsPaths.js
+++ b/lib/getStepDefinitionsPaths.js
@@ -20,8 +20,7 @@ const getStepDefinitionsPaths = filePath => {
     if (config.nonGlobalStepBaseDir) {
       const stepBase = `${appRoot}/${config.nonGlobalStepBaseDir}`;
       nonGlobalPath = nonGlobalPath.replace(stepDefinitionPath(), stepBase);
-      commonPath = `${nonGlobalPath}/${config.commonPath ||
-        `${stepBase}/common/`}`;
+      commonPath = `${nonGlobalPath}/../${config.commonPath || "common/"}`;
     }
 
     const nonGlobalPattern = `${nonGlobalPath}/**/*.+(js|ts)`;

--- a/lib/getStepDefinitionsPaths.test.js
+++ b/lib/getStepDefinitionsPaths.test.js
@@ -63,19 +63,43 @@ describe("getStepDefinitionsPaths", () => {
     expect(actual).to.include(expected);
   });
 
-  it("should return the overriden non global step definition pattern if nonGlobalStepBaseDir is defined", () => {
-    jest.spyOn(process, "cwd").mockImplementation(() => "cwd");
-    getConfig.mockReturnValue({
+  describe("nonGlobalStepBaseDir is defined", () => {
+    const path = "stepDefinitionPath/test.feature";
+    const config = {
       nonGlobalStepDefinitions: true,
       nonGlobalStepBaseDir: "nonGlobalStepBaseDir"
-    });
-    // eslint-disable-next-line global-require
-    const { getStepDefinitionsPaths } = require("./getStepDefinitionsPaths");
-    const path = "stepDefinitionPath/test.feature";
-    const actual = getStepDefinitionsPaths(path);
-    const expected = "cwd/nonGlobalStepBaseDir/test/**/*.+(js|ts)";
+    };
 
-    expect(actual).to.include(expected);
-    expect(actual).to.not.include("stepDefinitionPath/test/**/*.+(js|ts)");
+    beforeEach(() => {
+      jest.spyOn(process, "cwd").mockImplementation(() => "cwd");
+    });
+
+    it("should return the overriden non global step definition pattern and default common folder", () => {
+      getConfig.mockReturnValue(config);
+
+      const { getStepDefinitionsPaths } = require("./getStepDefinitionsPaths");
+      const actual = getStepDefinitionsPaths(path);
+
+      const expectedNonGlobalDefinitionPattern =
+        "cwd/nonGlobalStepBaseDir/test/**/*.+(js|ts)";
+      const expectedCommonPath =
+        "cwd/nonGlobalStepBaseDir/test/../common/**/*.+(js|ts)";
+
+      expect(actual).to.include(expectedNonGlobalDefinitionPattern);
+      expect(actual).to.include(expectedCommonPath);
+      expect(actual).to.not.include("stepDefinitionPath/test/**/*.+(js|ts)");
+    });
+
+    it("should return common folder defined by the dev and based on nonGlobalStepBaseDir", () => {
+      getConfig.mockReturnValue({ ...config, commonPath: "commonPath/" });
+
+      const { getStepDefinitionsPaths } = require("./getStepDefinitionsPaths");
+      const actual = getStepDefinitionsPaths(path);
+
+      const expectedCommonPath =
+        "cwd/nonGlobalStepBaseDir/test/../commonPath/**/*.+(js|ts)";
+
+      expect(actual).to.include(expectedCommonPath);
+    });
   });
 });

--- a/lib/getStepDefinitionsPaths.test.js
+++ b/lib/getStepDefinitionsPaths.test.js
@@ -83,7 +83,7 @@ describe("getStepDefinitionsPaths", () => {
       const expectedNonGlobalDefinitionPattern =
         "cwd/nonGlobalStepBaseDir/test/**/*.+(js|ts)";
       const expectedCommonPath =
-        "cwd/nonGlobalStepBaseDir/test/../common/**/*.+(js|ts)";
+        "cwd/nonGlobalStepBaseDir/common/**/*.+(js|ts)";
 
       expect(actual).to.include(expectedNonGlobalDefinitionPattern);
       expect(actual).to.include(expectedCommonPath);
@@ -97,7 +97,7 @@ describe("getStepDefinitionsPaths", () => {
       const actual = getStepDefinitionsPaths(path);
 
       const expectedCommonPath =
-        "cwd/nonGlobalStepBaseDir/test/../commonPath/**/*.+(js|ts)";
+        "cwd/nonGlobalStepBaseDir/commonPath/**/*.+(js|ts)";
 
       expect(actual).to.include(expectedCommonPath);
     });


### PR DESCRIPTION
fix the issue: when `nonGlobalStepBaseDir` is defined, and `nonGlobalStepDefinitions` is true, default `commonPath` is not correct and it is not `${nonGlobalStepBaseDir}/${commonPath}`