### PR TITLE
fix(docstring.feature): extend DocString.feature tests to cover failing scenario

### DIFF
--- a/cypress/integration/DocString.feature
+++ b/cypress/integration/DocString.feature
@@ -10,3 +10,12 @@ Feature: Being a plugin handling DocString scenario
     variableToVerify = "hello world"
     """
     Then I ran it and verify that it executes it
+
+  Scenario: DocString
+    When I use DocString for freemarker code like this
+    """
+    <div>
+      <h1>${ article.title }</h1>
+    </div>
+    """
+    Then I can interpret it as a string

--- a/cypress/support/step_definitions/docString.js
+++ b/cypress/support/step_definitions/docString.js
@@ -13,3 +13,12 @@ then("I ran it and verify that it executes it", () => {
   eval(code);
   expect(variableToVerify).to.equal("hello world");
 });
+
+let freemarkerSnippet = "";
+when("I use DocString for freemarker code like this", dataString => {
+  freemarkerSnippet = dataString;
+});
+
+then("I can interpret it as a string", () => {
+  expect(freemarkerSnippet).to.be.a("string");
+});

--- a/lib/featuresLoader.js
+++ b/lib/featuresLoader.js
@@ -23,7 +23,7 @@ const createCucumber = (
   window.cucumberJson = ${JSON.stringify(cucumberJson)};
 
   var moduleCache = arguments[5];
-  
+
   function clearFromCache(moduleId, instance){
     if(isWebpack()){
       delete require.cache[moduleId];
@@ -31,7 +31,7 @@ const createCucumber = (
       clearFromCacheBrowserify(instance);
     }
   }
-  
+
   function isWebpack(){
     return !!require.cache
   }
@@ -60,10 +60,10 @@ const createCucumber = (
           nonGlobalToRequire
             .find(fileSteps => fileSteps[filePath])
             [filePath].join("\n")}
-            
-        createTestsFromFeature('${path.basename(filePath)}', \`${jsStringEscape(
+
+        createTestsFromFeature('${path.basename(filePath)}', '${jsStringEscape(
         spec
-      )}\`);
+      )}');
         })
         `
     )

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -11,11 +11,11 @@ const { getCucumberJsonConfig } = require("./getCucumberJsonConfig");
 const createCucumber = (filePath, cucumberJson, spec, toRequire, name) =>
   `
   ${cucumberTemplate}
-  
+
   window.cucumberJson = ${JSON.stringify(cucumberJson)};
   describe(\`${name}\`, function() {
     ${toRequire.join("\n")}
-    createTestsFromFeature('${filePath}', \`${jsStringEscape(spec)}\`);
+    createTestsFromFeature('${filePath}', '${jsStringEscape(spec)}');
   });
   `;
 


### PR DESCRIPTION
Test case for reported issue https://github.com/TheBrainFamily/cypress-cucumber-preprocessor/issues/415

DocString.feature will fail when ES6 template literals are present in the DocString.

Open to suggestions/support on how this can be fixed.