### PR TITLE
Make logging skipped scenarios optional

### DIFF
--- a/lib/createTestFromScenario.js
+++ b/lib/createTestFromScenario.js
@@ -37,7 +37,10 @@ const stepTest = function (state, stepDetails, exampleRowData) {
 const runTest = (scenario, stepsToRun, rowData) => {
   const indexedSteps = stepsToRun.map((step, index) => ({ ...step, index }));
   // should skipped scenarios be logged?
-  const logSkipped = typeof Cypress.env("logSkipped") !== "undefined" ? Cypress.env("logSkipped") : true;
+  const logSkipped =
+    typeof Cypress.env("logSkipped") !== "undefined"
+      ? Cypress.env("logSkipped")
+      : true;
 
   // should we actually run this scenario
   // or just mark it as skipped

--- a/lib/createTestFromScenario.js
+++ b/lib/createTestFromScenario.js
@@ -37,7 +37,7 @@ const stepTest = function (state, stepDetails, exampleRowData) {
 const runTest = (scenario, stepsToRun, rowData) => {
   const indexedSteps = stepsToRun.map((step, index) => ({ ...step, index }));
   // should skipped scenarios be logged?
-  const logSkipped = (typeof Cypress.env("logSkipped") !== "undefined") ? Cypress.env("logSkipped") : true;
+  const logSkipped = typeof Cypress.env("logSkipped") !== "undefined" ? Cypress.env("logSkipped") : true;
 
   // should we actually run this scenario
   // or just mark it as skipped

--- a/lib/createTestFromScenario.js
+++ b/lib/createTestFromScenario.js
@@ -37,7 +37,7 @@ const stepTest = function (state, stepDetails, exampleRowData) {
 const runTest = (scenario, stepsToRun, rowData) => {
   const indexedSteps = stepsToRun.map((step, index) => ({ ...step, index }));
   // should skipped scenarios be logged?
-  const logSkipped = (typeof Cypress.env("logSkipped") != undefined) ? Cypress.env("logSkipped") : true;
+  const logSkipped = (typeof Cypress.env("logSkipped") !== undefined) ? Cypress.env("logSkipped") : true;
 
   // should we actually run this scenario
   // or just mark it as skipped

--- a/lib/createTestFromScenario.js
+++ b/lib/createTestFromScenario.js
@@ -36,6 +36,8 @@ const stepTest = function (state, stepDetails, exampleRowData) {
 
 const runTest = (scenario, stepsToRun, rowData) => {
   const indexedSteps = stepsToRun.map((step, index) => ({ ...step, index }));
+  // should skipped scenarios be logged?
+  const logSkipped = (typeof Cypress.env("logSkipped") != undefined) ? Cypress.env("logSkipped") : true
 
   // should we actually run this scenario
   // or just mark it as skipped
@@ -58,7 +60,7 @@ const runTest = (scenario, stepsToRun, rowData) => {
         )
         .then(() => state.onFinishScenario(scenario));
     });
-  } else {
+  } else if (logSkipped) {
     // eslint-disable-next-line func-names,prefer-arrow-callback
     it(scenario.name, function () {
       // register this scenario with the cucumber data collector

--- a/lib/createTestFromScenario.js
+++ b/lib/createTestFromScenario.js
@@ -37,7 +37,7 @@ const stepTest = function (state, stepDetails, exampleRowData) {
 const runTest = (scenario, stepsToRun, rowData) => {
   const indexedSteps = stepsToRun.map((step, index) => ({ ...step, index }));
   // should skipped scenarios be logged?
-  const logSkipped = (typeof Cypress.env("logSkipped") != undefined) ? Cypress.env("logSkipped") : true
+  const logSkipped = (typeof Cypress.env("logSkipped") != undefined) ? Cypress.env("logSkipped") : true;
 
   // should we actually run this scenario
   // or just mark it as skipped

--- a/lib/createTestFromScenario.js
+++ b/lib/createTestFromScenario.js
@@ -37,7 +37,7 @@ const stepTest = function (state, stepDetails, exampleRowData) {
 const runTest = (scenario, stepsToRun, rowData) => {
   const indexedSteps = stepsToRun.map((step, index) => ({ ...step, index }));
   // should skipped scenarios be logged?
-  const logSkipped = (typeof Cypress.env("logSkipped") !== undefined) ? Cypress.env("logSkipped") : true;
+  const logSkipped = (typeof Cypress.env("logSkipped") !== "undefined") ? Cypress.env("logSkipped") : true;
 
   // should we actually run this scenario
   // or just mark it as skipped


### PR DESCRIPTION
Adresses: Testrunner is flooded with skipped scenarios

Given I have a lot of scenarios in my feature file
And I add a focus tag to one scenario
When I run the feature in the test runner
Then I only want to see the execution log of the scenario with the focus tag
And I don't want to wait for the script runner to mark all other scenarios as skipped

Adresses: #419

Given I set the environment variable logSkipped to false
When I have some tests skipped during test execution
Then the cucumber report files do not include skipped scenarios
And I can successfully upload my report files to Zephyr Scale formerly known as TM4J
