### PR TITLE
fix: support multiline step arguments

### DIFF
--- a/cypress/integration/DocString.feature
+++ b/cypress/integration/DocString.feature
@@ -21,7 +21,7 @@ Feature: Being a plugin handling DocString scenario
     Then I can interpret it as a string
 
   Scenario Outline: DocString
-    When I use DocString with argument like this
+    When I use DocString with argument like this:
       """
       Hey,
       You have been granted <Role> rights.

--- a/cypress/integration/DocString.feature
+++ b/cypress/integration/DocString.feature
@@ -19,3 +19,17 @@ Feature: Being a plugin handling DocString scenario
     </div>
     """
     Then I can interpret it as a string
+
+  Scenario Outline: DocString
+    When I use DocString with argument like this
+      """
+      Hey,
+      You have been granted <Role> rights.
+      -The Admins
+      """
+    Then I should have a string with argument "<Role>"
+    
+   Examples:
+    |  Role     |
+    |  Manager  |
+    |  Admin    |

--- a/cypress/support/step_definitions/docString.js
+++ b/cypress/support/step_definitions/docString.js
@@ -30,6 +30,6 @@ Then("I can interpret it as a string", () => {
   expect(freemarkerSnippet).to.be.a("string");
 });
 
-Then(/^I should have a string with argument "([^"]*)"$/, function (argument: string) {
+Then(/^I should have a string with argument "([^"]*)"$/, function (argument) {
   expect(argString).to.contain(argument);
 });

--- a/cypress/support/step_definitions/docString.js
+++ b/cypress/support/step_definitions/docString.js
@@ -1,6 +1,7 @@
 /* global Then, When */
 
 let code = "";
+let argString = "";
 // eslint-disable-next-line prefer-const
 let variableToVerify = ""; // we are assigning this through eval
 
@@ -8,6 +9,10 @@ console.log(window);
 
 When("I use DocString for code like this:", (dataString) => {
   code = dataString;
+});
+
+When("I use DocString with argument like this:", (dataString) => {
+  argString = dataString;
 });
 
 Then("I ran it and verify that it executes it", () => {
@@ -23,4 +28,8 @@ When("I use DocString for freemarker code like this", (dataString) => {
 
 Then("I can interpret it as a string", () => {
   expect(freemarkerSnippet).to.be.a("string");
+});
+
+Then(/^I should have a string with argument "([^"]*)"$/, function (argument: string) {
+  expect(argString).to.contain(argument);
 });

--- a/lib/resolveStepDefinition.js
+++ b/lib/resolveStepDefinition.js
@@ -118,12 +118,10 @@ function resolveStepArgument(argument, exampleRowData, replaceParameterTags) {
 
     return new DataTable(argumentWithAppliedExampleData);
   }
-  
-  if (argument.type === "DocString" && exampleRowData) {
-    return replaceParameterTags(exampleRowData, argument.content);
-  }
-
-  if (argument.type === "DocString"&& !exampleRowData) {
+  if (argument.type === "DocString") {
+    if(exampleRowData) {
+      return replaceParameterTags(exampleRowData, argument.content);
+    }
     return argument.content;
   }
   

--- a/lib/resolveStepDefinition.js
+++ b/lib/resolveStepDefinition.js
@@ -118,9 +118,15 @@ function resolveStepArgument(argument, exampleRowData, replaceParameterTags) {
 
     return new DataTable(argumentWithAppliedExampleData);
   }
-  if (argument.type === "DocString") {
+  
+  if (argument.type === "DocString" && exampleRowData) {
+    return replaceParameterTags(exampleRowData, argument.content);
+  }
+
+  if (argument.type === "DocString"&& !exampleRowData) {
     return argument.content;
   }
+  
   return argument;
 }
 

--- a/lib/resolveStepDefinition.js
+++ b/lib/resolveStepDefinition.js
@@ -119,12 +119,12 @@ function resolveStepArgument(argument, exampleRowData, replaceParameterTags) {
     return new DataTable(argumentWithAppliedExampleData);
   }
   if (argument.type === "DocString") {
-    if(exampleRowData) {
+    if (exampleRowData) {
       return replaceParameterTags(exampleRowData, argument.content);
     }
     return argument.content;
   }
-  
+
   return argument;
 }
 


### PR DESCRIPTION
Add the functionality that the preprocessor also translates/replaces arguments in `DocString`.

This is a Documented Cucumber Feature:
https://github.com/yuyijq/cucumber/wiki/Multiline-Step-Arguments#substitution-in-scenario-outlines