### PR TITLE
feat(createtestfromscenario.js): add suffix to generated json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ This behaviour is configurable. Use [cosmiconfig](https://github.com/davidthecla
       "generate": true,
       "outputFolder": "cypress/cucumber-json",
       "filePrefix": "",
-      "fileSuffix": ".cucumber"
+      "fileSuffix": ""
     }
   }
 ```
@@ -422,8 +422,8 @@ This behaviour is configurable. Use [cosmiconfig](https://github.com/davidthecla
 Option | Default value | Description
 ------------ | ------------- | -------------
 outputFolder | `cypress/cucumber-json` | The folder to write the files to
-filePrefix | `''` *(no prefix)* | A separate json file is generated for each feature based on the name of the feature file. All generated file names will be prefixed with this option if specified
-fileSuffix | `.cucumber` | A suffix to add to each generated filename
+filePrefix | `''` *(no prefix)* | A separate json file is generated for each feature based on the name of the feature file. If specified, all generated file names will be prefixed with specified `string`
+fileSuffix | `''` *(generated alphanumeric suffix)* | If default values are used, then it adds underscore and randomly generated alphanumeric suffix for each generated filename (e.g `_oK9x`). If specified, all generated file names will be suffixed with specified `string` 
 generate | `false` | Flag to output cucumber.json or not
 
 ## IDE support

--- a/lib/createTestFromScenario.js
+++ b/lib/createTestFromScenario.js
@@ -77,11 +77,22 @@ const runTest = (scenario, stepsToRun, rowData) => {
 
 const cleanupFilename = (s) => s.split(".")[0];
 
+function randomString(length) {
+  let text = "";
+  const possible =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+  for (let i = 0; i < length; i += 1) {
+    text += possible.charAt(Math.floor(Math.random() * possible.length));
+  }
+  return text;
+}
+
 const writeCucumberJsonFile = (json) => {
   const outputFolder =
     window.cucumberJson.outputFolder || "cypress/cucumber-json";
   const outputPrefix = window.cucumberJson.filePrefix || "";
-  const outputSuffix = window.cucumberJson.fileSuffix || ".cucumber";
+  const outputSuffix = window.cucumberJson.fileSuffix || `_${randomString(4)}`;
   const fileName = json[0] ? cleanupFilename(json[0].uri) : "empty";
   const outFile = `${outputFolder}/${outputPrefix}${fileName}${outputSuffix}.json`;
   cy.writeFile(outFile, json, { log: false });


### PR DESCRIPTION
###  What
This change will generate random suffix for the generated json files, when it isn't defined in the `package.json`
```
 "cypress-cucumber-preprocessor": {
    "cucumberJson": {
      "filePrefix": "",
      "fileSuffix": ""
    }
  }
```
### Why
Let's assume we have following files in following folders:
```
└───foo
    └───satisfaction.feature
└───bar
    └───satisfaction.feature
```
Currently there's only one file generated per feature. From our example above it means, that **json file from bar folder will overwrite json file from foo folder.**
So at the end of the run there's **only 1 json file instead of 2**
By generating random suffix we end up with something like:
```
satisfaction_xOw8.json
satisfaction_aNP4.json
```