### PR TITLE
fix(createtestfromscenario): switch from using Cypress fail event to …

### DIFF
--- a/lib/createTestFromScenario.js
+++ b/lib/createTestFromScenario.js
@@ -103,12 +103,10 @@ const createTestFromScenarios = (
     window.testState = testState;
 
     const failHandler = (err) => {
-      Cypress.off("fail", failHandler);
       testState.onFail(err);
-      throw err;
     };
 
-    Cypress.on("fail", failHandler);
+    Cypress.mocha.getRunner().on("fail", failHandler);
   });
 
   allScenarios.forEach((section) => {

--- a/lib/testHelpers/setupTestFramework.js
+++ b/lib/testHelpers/setupTestFramework.js
@@ -10,6 +10,13 @@ window.Cypress = {
   on: jest.fn(),
   off: jest.fn(),
   log: jest.fn(),
+  mocha: {
+    getRunner: () => {
+      return {
+        on: jest.fn(),
+      };
+    },
+  },
   Promise: { each: (iterator, iteree) => iterator.map(iteree) },
 };
 


### PR DESCRIPTION
…mocha runner fail event

it seems that cypress fail event could have only one listener (https://github.com/Shelex/cypress-allure-plugin/issues/57#issuecomment-804269841) and in case user has own or other
plugins use it cucumber json will be missing results for failed tests as this event is not emitted

re #459, #454, #417, #348