### PR TITLE
fix(createtestfromscenario.js): after hook is not being called if one…

### DIFF
--- a/cypress/integration/BeforeAndAfterSteps.feature
+++ b/cypress/integration/BeforeAndAfterSteps.feature
@@ -11,6 +11,14 @@ Scenario: With Untagged After part 1
 Scenario: With Untagged After part 2
   Then Flag should be set by untagged After
 
+# After is tested in following scenario by verifying that the After ran at the end of the previous one
+# Note: Since this test requires that a scenario fails, it must be run manually enabled and run and
+# "Given I executed step causing error" is expected to cause an error
+# Scenario: With Untagged After having test errors in steps part 1
+#   Given I executed step causing error
+# Scenario: With Untagged After having test errors in steps part 2
+#   Then Error flag should be set by untagged After
+
 # After is tested in following scenario by verifying that the After ran at the end of the previous one.
 @withTaggedAfter
 Scenario: With tagged After part 1
@@ -18,6 +26,16 @@ Scenario: With tagged After part 1
 
 Scenario: With tagged After part 2
   Then Flag should be set by tagged After
+
+# After is tested in following scenario by verifying that the After ran at the end of the previous one.
+# Note: Since this test requires that a scenario fails, it must be run manually enabled and run and
+# "Given I executed step causing error" is expected to cause an error
+@withTaggedErroredAfter
+# Scenario: With tagged After having test errors part 1
+#   Given I executed step causing error
+#
+# Scenario: With tagged After having test errors part 2
+#   Then Error flag should be set by tagged After
 
 @withTaggedBefore
 Scenario: With tagged Before only

--- a/cypress/support/step_definitions/before_and_after_steps.js
+++ b/cypress/support/step_definitions/before_and_after_steps.js
@@ -11,6 +11,8 @@ let beforeCounter = 0;
 let beforeWithTagCounter = 0;
 let flagSetByUntaggedAfter = false;
 let flagSetByTaggedAfter = false;
+let flagSetByUntaggedAfterWithError = false;
+let flagSetByTaggedAfterWithError = false;
 
 Before(() => {
   beforeCounter += 1;
@@ -36,10 +38,15 @@ After({ tags: "@willNeverRun" }, () => {
 After(() => {
   beforeCounter = 0;
   flagSetByUntaggedAfter = true;
+  flagSetByUntaggedAfterWithError = true;
 });
 
 After({ tags: "@withTaggedAfter" }, () => {
   flagSetByTaggedAfter = true;
+});
+
+After({ tags: "@withTaggedErroredAfter" }, () => {
+  flagSetByTaggedAfterWithError = true;
 });
 
 Given("I executed empty step", () => {});
@@ -70,4 +77,18 @@ Then("Flag should be set by untagged After", () => {
 
 Then("Flag should be set by tagged After", () => {
   expect(flagSetByTaggedAfter).to.equal(true);
+});
+
+Given("I executed step causing error", () => {
+  flagSetByUntaggedAfterWithError = false;
+  flagSetByTaggedAfterWithError = false;
+  throw new Error("Error executing step: I executed step causing error");
+});
+
+Then("Error flag should be set by untagged After", () => {
+  expect(flagSetByUntaggedAfterWithError).to.equal(true);
+});
+
+Then("Error flag should be set by tagged After", () => {
+  expect(flagSetByTaggedAfterWithError).to.equal(true);
 });

--- a/lib/createTestFromScenario.js
+++ b/lib/createTestFromScenario.js
@@ -53,9 +53,6 @@ const runTest = (scenario, stepsToRun, rowData) => {
             stepTest.call(this, state, step, rowData)
           )
         )
-        .then(() =>
-          resolveAndRunAfterHooks.call(this, scenario.tags, state.feature.name)
-        )
         .then(() => state.onFinishScenario(scenario));
     });
   } else {
@@ -165,6 +162,19 @@ const createTestFromScenarios = (
         writeCucumberJsonFile(json);
       }
     });
+  });
+
+  // eslint-disable-next-line func-names, prefer-arrow-callback
+  afterEach(function () {
+    if (testState.currentScenario && testState.currentScenario.shouldRun) {
+      cy.then(() =>
+        resolveAndRunAfterHooks.call(
+          this,
+          testState.currentScenario.tags,
+          testState.feature.name
+        )
+      );
+    }
   });
 };
 


### PR DESCRIPTION
We need the After method to be executed even if the one the steps failed.

The problem with using Before to clear the state is that our application has a lot of complexity, relations between entities etc. Our environments are even deployed pre-populated in order to execute tests as our applications is on top of three other really complex ones.

This is the suggested PR from the ongoing discussion in this issue https://github.com/TheBrainFamily/cypress-cucumber-preprocessor/issues/398

After hook is executed when the scenario fails. 