### PR TITLE
feat(getstepdefinitionpaths.js): allow tsx extension for step definition files

### DIFF
--- a/lib/getStepDefinitionsPaths.js
+++ b/lib/getStepDefinitionsPaths.js
@@ -23,15 +23,15 @@ const getStepDefinitionsPaths = (filePath) => {
       commonPath = `${stepBase}/${config.commonPath || "common/"}`;
     }
 
-    const nonGlobalPattern = `${nonGlobalPath}/**/*.+(js|ts)`;
+    const nonGlobalPattern = `${nonGlobalPath}/**/*.+(js|ts|tsx)`;
 
-    const commonDefinitionsPattern = `${commonPath}**/*.+(js|ts)`;
+    const commonDefinitionsPattern = `${commonPath}**/*.+(js|ts|tsx)`;
     paths = paths.concat(
       glob.sync(nonGlobalPattern),
       glob.sync(commonDefinitionsPattern)
     );
   } else {
-    const pattern = `${stepDefinitionPath()}/**/*.+(js|ts)`;
+    const pattern = `${stepDefinitionPath()}/**/*.+(js|ts|tsx)`;
     paths = paths.concat(glob.sync(pattern));
   }
   return paths;

--- a/lib/getStepDefinitionsPaths.test.js
+++ b/lib/getStepDefinitionsPaths.test.js
@@ -23,7 +23,7 @@ describe("getStepDefinitionsPaths", () => {
     const { getStepDefinitionsPaths } = require("./getStepDefinitionsPaths");
 
     const actual = getStepDefinitionsPaths("/path");
-    const expected = "stepDefinitionPath/common/**/*.+(js|ts)";
+    const expected = "stepDefinitionPath/common/**/*.+(js|ts|tsx)";
     expect(actual).to.include(expected);
   });
 
@@ -47,7 +47,7 @@ describe("getStepDefinitionsPaths", () => {
     const { getStepDefinitionsPaths } = require("./getStepDefinitionsPaths");
 
     const actual = getStepDefinitionsPaths("/path");
-    const expected = "./cwd/myPath/**/*.+(js|ts)";
+    const expected = "./cwd/myPath/**/*.+(js|ts|tsx)";
     expect(actual).to.include(expected);
   });
   it("should return the default non global step definition pattern", () => {
@@ -58,7 +58,7 @@ describe("getStepDefinitionsPaths", () => {
     const { getStepDefinitionsPaths } = require("./getStepDefinitionsPaths");
     const path = "stepDefinitionPath/test.feature";
     const actual = getStepDefinitionsPaths(path);
-    const expected = "stepDefinitionPath/test/**/*.+(js|ts)";
+    const expected = "stepDefinitionPath/test/**/*.+(js|ts|tsx)";
 
     expect(actual).to.include(expected);
   });
@@ -81,13 +81,15 @@ describe("getStepDefinitionsPaths", () => {
       const actual = getStepDefinitionsPaths(path);
 
       const expectedNonGlobalDefinitionPattern =
-        "cwd/nonGlobalStepBaseDir/test/**/*.+(js|ts)";
+        "cwd/nonGlobalStepBaseDir/test/**/*.+(js|ts|tsx)";
       const expectedCommonPath =
-        "cwd/nonGlobalStepBaseDir/common/**/*.+(js|ts)";
+        "cwd/nonGlobalStepBaseDir/common/**/*.+(js|ts|tsx)";
 
       expect(actual).to.include(expectedNonGlobalDefinitionPattern);
       expect(actual).to.include(expectedCommonPath);
-      expect(actual).to.not.include("stepDefinitionPath/test/**/*.+(js|ts)");
+      expect(actual).to.not.include(
+        "stepDefinitionPath/test/**/*.+(js|ts|tsx)"
+      );
     });
 
     it("should return common folder defined by the dev and based on nonGlobalStepBaseDir", () => {
@@ -97,7 +99,7 @@ describe("getStepDefinitionsPaths", () => {
       const actual = getStepDefinitionsPaths(path);
 
       const expectedCommonPath =
-        "cwd/nonGlobalStepBaseDir/commonPath/**/*.+(js|ts)";
+        "cwd/nonGlobalStepBaseDir/commonPath/**/*.+(js|ts|tsx)";
 
       expect(actual).to.include(expectedCommonPath);
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -73,9 +73,16 @@ const preprocessor = (options = browserify.defaultOptions) => {
         watcher.close();
       }
       watcher = chokidar
-        .watch([`${stepDefinitionPath()}*.js`, `${stepDefinitionPath()}*.ts`], {
-          ignoreInitial: true,
-        })
+        .watch(
+          [
+            `${stepDefinitionPath()}*.js`,
+            `${stepDefinitionPath()}*.ts`,
+            `${stepDefinitionPath()}*.tsx`,
+          ],
+          {
+            ignoreInitial: true,
+          }
+        )
         .on("all", () => {
           touch(file.filePath);
         });


### PR DESCRIPTION
This may be a (very) niche use case but I use a custom flavour of JSX in my step files to create initial data for a test.