### PR TITLE
fix(featuresloader): safe usage of arguments to support webpack 5

### DIFF
--- a/lib/featuresLoader.js
+++ b/lib/featuresLoader.js
@@ -22,7 +22,12 @@ const createCucumber = (
     ${cucumberTemplate}
   window.cucumberJson = ${JSON.stringify(cucumberJson)};
 
-  var moduleCache = arguments[5];
+  var moduleCache = {};
+  try {
+    moduleCache = arguments[5];
+  } catch (e) {
+    console.log('Cannot get arguments: this value is not available in webpack 5+. moduleCache is empty.');
+  }
 
   function clearFromCache(moduleId, instance){
     if(isWebpack()){


### PR DESCRIPTION
Attempt to use featuresLoader.js with webpack 5 fails because webpack 5 doesn't provide "arguments" argument, that is used currently in code. I suppose it was used especially for browserify and previous version of webpack was less strict and allowed to use this argument as well.

Variable "moduleCache" is used only for "browserify" feature branch. Therefore, some refactoring with strict separation between webpack and browserify could be performed in the future as well.