### PR TITLE
fix(cypress-tags.js): scenario outlines with examples were not correctly filtered by tags

### DIFF
--- a/cypress-tags.js
+++ b/cypress-tags.js
@@ -71,31 +71,29 @@ const paths = glob
   })
   .filter((pathName) => pathName.endsWith(".feature"));
 
-const featuresToRun = [];
-
-paths.forEach((featurePath) => {
+const featuresToRun = paths.filter((featurePath) => {
   const spec = `${fs.readFileSync(featurePath)}`;
-  const parsedFeature = new Parser().parse(spec);
+  const { feature } = new Parser().parse(spec);
 
-  if (!parsedFeature.feature) {
+  if (!feature) {
     debug(`Feature: ${featurePath} is empty`);
-    return;
+    return false;
   }
 
-  const featureTags = parsedFeature.feature.tags;
-  const featureShouldRun = shouldProceedCurrentStep(featureTags, envTags);
-  const taggedScenarioShouldRun = parsedFeature.feature.children.some(
-    (section) =>
-      section.tags &&
-      section.tags.length &&
-      shouldProceedCurrentStep(section.tags.concat(featureTags), envTags)
+  const shouldRun = feature.children.some((scenario) =>
+    scenario.examples
+      ? scenario.examples.some((example) =>
+          shouldProceedCurrentStep(
+            [...example.tags, ...scenario.tags, ...feature.tags],
+            envTags
+          )
+        )
+      : shouldProceedCurrentStep([...scenario.tags, ...feature.tags], envTags)
   );
-  debug(
-    `Feature: ${featurePath}, featureShouldRun: ${featureShouldRun}, taggedScenarioShouldRun: ${taggedScenarioShouldRun}`
-  );
-  if (featureShouldRun || taggedScenarioShouldRun) {
-    featuresToRun.push(featurePath);
-  }
+
+  debug(`Feature: ${featurePath}, shouldRun: ${shouldRun}`);
+
+  return shouldRun;
 });
 
 function getOsSpecificExecutable(command) {

--- a/cypress-tags.js
+++ b/cypress-tags.js
@@ -84,11 +84,14 @@ const featuresToRun = paths.filter((featurePath) => {
     scenario.examples
       ? scenario.examples.some((example) =>
           shouldProceedCurrentStep(
-            [...example.tags, ...scenario.tags, ...feature.tags],
+            [...example.tags, ...(scenario.tags || []), ...feature.tags],
             envTags
           )
         )
-      : shouldProceedCurrentStep([...scenario.tags, ...feature.tags], envTags)
+      : shouldProceedCurrentStep(
+          [...(scenario.tags || []), ...feature.tags],
+          envTags
+        )
   );
 
   debug(`Feature: ${featurePath}, shouldRun: ${shouldRun}`);


### PR DESCRIPTION
Now the script supports filtering examples of scenario outlines too. I have removed the optimization
that we should check scenario tags if there are any, because they do not work for negated tags (e.g.
`not @tag1`). Additionally, just checking the feature tag itself is also wrong, because a feature
with tag `@feature` having a scenario with tag `@scenario` would incorrectly run when we filter for
`not @scenario`. So the best is to leave the tag checking for "leaf nodes", i.e. scenarios or
examples. Also consider the corner case where a feature has no scenarios or scenario outlines at
all, i.e. again we would not run such a feature at all.

Fixes #196.