### PR TITLE
Update Cypress devDependency to support Cypress 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "commitizen": "^4.2.1",
-    "cypress": "^5.1.0",
+    "cypress": ">=5.1 <=8",
     "cz-conventional-changelog": "^3.3.0",
     "eslint": "^7.9.0",
     "eslint-config-airbnb-base": "^14.2.0",


### PR DESCRIPTION
This package has been used successfully by me and other user with Cypress 8 https://github.com/TheBrainFamily/cypress-cucumber-preprocessor/issues/554#issuecomment-895659811 so I believe the devDependency should be update to support Cypress up to version 8