### PR TITLE
update documentation for typescript support

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,12 +481,12 @@ is supported out-of-the-box. To use it, add this to your `plugins/index.js`:
 ```javascript
 const browserify = require('@cypress/browserify-preprocessor');
 const cucumber = require('cypress-cucumber-preprocessor').default;
-const resolve = require('resolve');
+const path = require('path');
 
 module.exports = (on, config) => {
   const options = {
     ...browserify.defaultOptions,
-    typescript: resolve.sync('typescript', { baseDir: config.projectRoot }),
+    typescript: path.join(path.resolve('..'), 'node_modules/typescript'),
   };
 
   on('file:preprocessor', cucumber(options));


### PR DESCRIPTION
The typescript support that is documented is only running until Cypress 8.5.0. As of Cypress version 8.6.0 it should be done in another way without using `resolve.sync()`. But this new solution is also working with Cypress version <= 8.5.0 and of course also for higher versions.