### PR TITLE
Upgrade dependency mocha to fix vulnerability in serialize-javascript

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "fp-ts": "^2.16.11",
     "glob": "^13.0.0",
     "io-ts": "^2.2.22",
+    "mocha": "^11.0.0",
     "seedrandom": "^3.0.5",
     "split": "^1.0.1",
     "uuid": "^14.0.0"
@@ -116,7 +117,6 @@
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "genversion": "^3.2.0",
     "jsdom": "^29.0.2",
-    "mocha": "^12.0.0-rc.1",
     "pngjs": "^7.0.0",
     "prettier": "^3.3.3",
     "recast": "^0.23.9",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "fp-ts": "^2.16.11",
     "glob": "^13.0.0",
     "io-ts": "^2.2.22",
-    "mocha": "^11.0.0",
     "seedrandom": "^3.0.5",
     "split": "^1.0.1",
     "uuid": "^14.0.0"
@@ -117,6 +116,7 @@
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "genversion": "^3.2.0",
     "jsdom": "^29.0.2",
+    "mocha": "^12.0.0-rc.1",
     "pngjs": "^7.0.0",
     "prettier": "^3.3.3",
     "recast": "^0.23.9",


### PR DESCRIPTION
Upgrade dependency mocha to fix vulnerability in serialize-javascript (this vuln is still there in release 26.0.0 of cypress-cucumber-preprocessor). Making this change when I tested locally, pulled in 7.0.7 of serialize-javascript